### PR TITLE
build: add NuGet package metadata, README, icon, and IsPackable guards

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,23 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latest</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+
+    <!-- NuGet package metadata -->
+    <Authors>Marcel Roozekrans</Authors>
+    <Company>Marcel Roozekrans</Company>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/ZeroAlloc-Net/ZeroAlloc.Validation</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/ZeroAlloc-Net/ZeroAlloc.Validation</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageTags>validation;source-generator;zero-allocation;roslyn;attributes</PackageTags>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageIcon>icon.png</PackageIcon>
+    <Copyright>Copyright (c) Marcel Roozekrans</Copyright>
   </PropertyGroup>
+  <ItemGroup Condition="'$(IsPackable)' != 'false'">
+    <None Include="$(MSBuildThisFileDirectory)README.md" Pack="true" PackagePath="\" />
+    <None Include="$(MSBuildThisFileDirectory)assets\icon.png" Pack="true" PackagePath="\" />
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Meziantou.Analyzer" Version="3.0.23" PrivateAssets="all">

--- a/src/ZeroAlloc.Validation.AspNetCore.Generator/ZeroAlloc.Validation.AspNetCore.Generator.csproj
+++ b/src/ZeroAlloc.Validation.AspNetCore.Generator/ZeroAlloc.Validation.AspNetCore.Generator.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
     <IsRoslynComponent>true</IsRoslynComponent>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ZeroAlloc.Validation.AspNetCore/ZeroAlloc.Validation.AspNetCore.csproj
+++ b/src/ZeroAlloc.Validation.AspNetCore/ZeroAlloc.Validation.AspNetCore.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <PackageId>ZeroAlloc.Validation.AspNetCore</PackageId>
+    <Description>ASP.NET Core integration for ZeroAlloc.Validation. Source-generated action filter validates request models at compile time with zero runtime overhead.</Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ZeroAlloc.Validation.Generator/ZeroAlloc.Validation.Generator.csproj
+++ b/src/ZeroAlloc.Validation.Generator/ZeroAlloc.Validation.Generator.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
     <IsRoslynComponent>true</IsRoslynComponent>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ZeroAlloc.Validation.Testing/ZeroAlloc.Validation.Testing.csproj
+++ b/src/ZeroAlloc.Validation.Testing/ZeroAlloc.Validation.Testing.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <PackageId>ZeroAlloc.Validation.Testing</PackageId>
+    <Description>Testing helpers for ZeroAlloc.Validation. Provides assertion utilities to verify validation results in unit tests.</Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ZeroAlloc.Validation/ZeroAlloc.Validation.csproj
+++ b/src/ZeroAlloc.Validation/ZeroAlloc.Validation.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <PackageId>ZeroAlloc.Validation</PackageId>
+    <Description>A zero-allocation validation library for .NET. Roslyn source generator wires all rule evaluation at compile time — no reflection, no boxing, no runtime overhead.</Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -1,0 +1,6 @@
+<Project>
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
## Summary
- Adds NuGet metadata to `Directory.Build.props`: authors, license (MIT), README, icon, tags, repository URL
- Adds `PackageId` and per-package descriptions to `ZeroAlloc.Validation`, `ZeroAlloc.Validation.AspNetCore`, `ZeroAlloc.Validation.Testing`
- Marks generator projects (`IsPackable=false`) so they are not published as standalone packages
- Adds `tests/Directory.Build.props` to mark all test projects as non-packable

## Test Plan
- [ ] CI build passes
- [ ] NuGet packages include README and icon after next release