### PR TITLE
fix: correct Build badge URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ZeroAlloc.Validation
 
 [![NuGet](https://img.shields.io/nuget/v/ZeroAlloc.Validation)](https://www.nuget.org/packages/ZeroAlloc.Validation)
-![Build](https://img.shields.io/github/actions/workflow/status/placeholder/ci.yml)
+![Build](https://img.shields.io/github/actions/workflow/status/ZeroAlloc-Net/ZeroAlloc.Validation/ci.yml?branch=main)
 ![License](https://img.shields.io/badge/license-MIT-blue)
 
 Source-generated, attribute-based validation for .NET that allocates nothing on the valid path. The source generator emits a strongly-typed validator class at build time — no reflection at runtime. When all rules pass, the entire validation cycle produces zero heap allocations.


### PR DESCRIPTION
## Summary
- Fixes the Build badge URL which had a `placeholder` path instead of the real repo path `ZeroAlloc-Net/ZeroAlloc.Validation`

## Why
This `fix:` commit is needed so release-please creates a v0.1.2 release PR, which will publish the NuGet packages with the correct metadata (README, icon, description) added in #2.