### PR TITLE
ci: add workflow_dispatch and trigger website rebuild on docs change

### DIFF
--- a/.github/workflows/trigger-website.yml
+++ b/.github/workflows/trigger-website.yml
@@ -1,0 +1,20 @@
+# Copy this file to .github/workflows/trigger-website.yml in each library repo.
+# Requires a secret named WEBSITE_DISPATCH_TOKEN with Actions:write permission on ZeroAlloc-Net/.website
+name: Trigger website rebuild
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch to .website repo
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.WEBSITE_DISPATCH_TOKEN }}
+          repository: ZeroAlloc-Net/.website
+          event-type: submodule-update


### PR DESCRIPTION
## Summary
- Add `workflow_dispatch` trigger so CI can be manually run on any branch
- Add `trigger-website.yml` — dispatches a `submodule-update` event to `ZeroAlloc-Net/.website` whenever `docs/**` changes on `main`, triggering an automatic submodule bump and Cloudflare rebuild

> **Requires:** `WEBSITE_DISPATCH_TOKEN` org-level secret (fine-grained PAT with `Actions: write` on `ZeroAlloc-Net/.website`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)