### PR TITLE
ci: add AOT publish smoke test (item 1 of #18)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,3 +52,30 @@ jobs:
       - name: Push to NuGet (pre-release)
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: dotnet nuget push ./artifacts/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+
+  aot-smoke:
+    runs-on: ubuntu-latest
+    # Publishes samples/ZeroAlloc.Validation.AotSmoke with PublishAot=true and
+    # runs the binary. Exercises the generator-emitted AddressValidator —
+    # [Validate] + [NotEmpty] attributes resolved into a zero-reflection check.
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Install AOT native toolchain
+        run: sudo apt-get update && sudo apt-get install -y clang zlib1g-dev
+
+      - name: Restore
+        run: dotnet restore samples/ZeroAlloc.Validation.AotSmoke/ZeroAlloc.Validation.AotSmoke.csproj
+
+      - name: Publish AOT
+        run: dotnet publish samples/ZeroAlloc.Validation.AotSmoke/ZeroAlloc.Validation.AotSmoke.csproj -r linux-x64 -c Release -o ./aot-out
+
+      - name: Run AOT binary
+        run: ./aot-out/ZeroAlloc.Validation.AotSmoke

--- a/ZeroAlloc.Validation.slnx
+++ b/ZeroAlloc.Validation.slnx
@@ -9,6 +9,9 @@
     <Project Path="src/ZeroAlloc.Validation.Testing/ZeroAlloc.Validation.Testing.csproj" />
     <Project Path="src/ZeroAlloc.Validation/ZeroAlloc.Validation.csproj" />
   </Folder>
+  <Folder Name="/samples/">
+    <Project Path="samples/ZeroAlloc.Validation.AotSmoke/ZeroAlloc.Validation.AotSmoke.csproj" />
+  </Folder>
   <Folder Name="/tests/">
     <Project Path="tests/ZeroAlloc.Validation.Tests.AspNetCore/ZeroAlloc.Validation.Tests.AspNetCore.csproj" />
     <Project Path="tests/ZeroAlloc.Validation.Tests.Inject/ZeroAlloc.Validation.Tests.Inject.csproj" />

--- a/samples/ZeroAlloc.Validation.AotSmoke/Address.cs
+++ b/samples/ZeroAlloc.Validation.AotSmoke/Address.cs
@@ -1,0 +1,13 @@
+using ZeroAlloc.Validation;
+
+namespace ZeroAlloc.Validation.AotSmoke;
+
+[Validate]
+public sealed class Address
+{
+    [NotEmpty(Message = "Street is required.")]
+    public string Street { get; set; } = "";
+
+    [NotEmpty]
+    public string City { get; set; } = "";
+}

--- a/samples/ZeroAlloc.Validation.AotSmoke/Program.cs
+++ b/samples/ZeroAlloc.Validation.AotSmoke/Program.cs
@@ -1,0 +1,34 @@
+using System;
+using ZeroAlloc.Validation.AotSmoke;
+
+// Exercise the generator-emitted AddressValidator under PublishAot=true.
+// The generator emits a ValidatorFor<Address> subclass that evaluates every
+// [NotEmpty]/etc. attribute at compile time — no reflection.
+
+var validator = new AddressValidator();
+
+// Invalid input: both fields empty → 2 failures expected.
+var empty = validator.Validate(new Address());
+if (empty.IsValid)
+{
+    Console.Error.WriteLine("AOT smoke: FAIL — empty Address should be invalid");
+    return 1;
+}
+
+var emptyFailures = System.Linq.Enumerable.Count(empty.Failures.ToArray());
+if (emptyFailures != 2)
+{
+    Console.Error.WriteLine($"AOT smoke: FAIL — empty Address expected 2 failures, got {emptyFailures}");
+    return 1;
+}
+
+// Valid input: both fields populated → no failures.
+var ok = validator.Validate(new Address { Street = "Main St 1", City = "Amsterdam" });
+if (!ok.IsValid)
+{
+    Console.Error.WriteLine("AOT smoke: FAIL — fully-populated Address should be valid");
+    return 1;
+}
+
+Console.WriteLine("AOT smoke: PASS");
+return 0;

--- a/samples/ZeroAlloc.Validation.AotSmoke/ZeroAlloc.Validation.AotSmoke.csproj
+++ b/samples/ZeroAlloc.Validation.AotSmoke/ZeroAlloc.Validation.AotSmoke.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <RootNamespace>ZeroAlloc.Validation.AotSmoke</RootNamespace>
+    <IsPackable>false</IsPackable>
+    <PublishAot>true</PublishAot>
+    <InvariantGlobalization>true</InvariantGlobalization>
+    <OptimizationPreference>Size</OptimizationPreference>
+
+    <WarningsAsErrors>$(WarningsAsErrors);IL2026;IL2067;IL2075;IL2091;IL3050;IL3051</WarningsAsErrors>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\ZeroAlloc.Validation\ZeroAlloc.Validation.csproj"
+                      SetTargetFramework="TargetFramework=net10.0" />
+    <ProjectReference Include="..\..\src\ZeroAlloc.Validation.Generator\ZeroAlloc.Validation.Generator.csproj"
+                      OutputItemType="Analyzer"
+                      ReferenceOutputAssembly="false"
+                      UndefineProperties="PublishAot" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
First item of #18. Exercises the generator-emitted `AddressValidator` (`ValidatorFor<Address>`) under `PublishAot=true` — invalid + valid input paths both checked.