### PR TITLE
ci(release): publish Validation.Inject and Validation.Options to NuGet

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -47,6 +47,8 @@ jobs:
           dotnet pack src/ZeroAlloc.Validation.AspNetCore/ZeroAlloc.Validation.AspNetCore.csproj -c Release --no-build -p:PackageVersion=${{ needs.release-please.outputs.version }} -o ./nupkg
           dotnet pack src/ZeroAlloc.Validation.AspNetCore.Generator/ZeroAlloc.Validation.AspNetCore.Generator.csproj -c Release --no-build -p:PackageVersion=${{ needs.release-please.outputs.version }} -o ./nupkg
           dotnet pack src/ZeroAlloc.Validation.Testing/ZeroAlloc.Validation.Testing.csproj -c Release --no-build -p:PackageVersion=${{ needs.release-please.outputs.version }} -o ./nupkg
+          dotnet pack src/ZeroAlloc.Validation.Inject/ZeroAlloc.Validation.Inject.csproj -c Release --no-build -p:PackageVersion=${{ needs.release-please.outputs.version }} -o ./nupkg
+          dotnet pack src/ZeroAlloc.Validation.Options/ZeroAlloc.Validation.Options.csproj -c Release --no-build -p:PackageVersion=${{ needs.release-please.outputs.version }} -o ./nupkg
 
       - name: Push to NuGet
         run: dotnet nuget push ./nupkg/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,8 @@ jobs:
           dotnet pack src/ZeroAlloc.Validation.AspNetCore/ZeroAlloc.Validation.AspNetCore.csproj --no-build -c Release -p:PackageVersion=${{ steps.version.outputs.version }} -o ./artifacts
           dotnet pack src/ZeroAlloc.Validation.AspNetCore.Generator/ZeroAlloc.Validation.AspNetCore.Generator.csproj --no-build -c Release -p:PackageVersion=${{ steps.version.outputs.version }} -o ./artifacts
           dotnet pack src/ZeroAlloc.Validation.Testing/ZeroAlloc.Validation.Testing.csproj --no-build -c Release -p:PackageVersion=${{ steps.version.outputs.version }} -o ./artifacts
+          dotnet pack src/ZeroAlloc.Validation.Inject/ZeroAlloc.Validation.Inject.csproj --no-build -c Release -p:PackageVersion=${{ steps.version.outputs.version }} -o ./artifacts
+          dotnet pack src/ZeroAlloc.Validation.Options/ZeroAlloc.Validation.Options.csproj --no-build -c Release -p:PackageVersion=${{ steps.version.outputs.version }} -o ./artifacts
 
       - name: Push to NuGet
         run: dotnet nuget push ./artifacts/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json


### PR DESCRIPTION
## Summary
The release workflows previously only packed Validation core, Generator, AspNetCore, AspNetCore.Generator, and Testing. Two packages — Validation.Inject and Validation.Options — were never published to NuGet despite having explicit `<PackageId>` declarations and being publishable.

This PR extends both release workflows to pack and push both packages alongside the existing list. Same fix pattern as ZeroAlloc.Mediator#54.

## Affected packages (now publishable)
- ZeroAlloc.Validation.Inject
- ZeroAlloc.Validation.Options

## Test plan
- [x] dotnet pack succeeds for both packages locally
- [ ] Next release-please cycle publishes all 7 packages (verify post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)