### PR TITLE
chore(release): promote ZeroAlloc.Validation to 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.0
+
+Stability milestone — public API of `ZeroAlloc.Validation` is now considered stable. Bundles PR #20 (CI: publish ZeroAlloc.Validation.Inject and ZeroAlloc.Validation.Options to NuGet). This release marks the transition out of pre-1.0 SemVer.
+
 ## [0.2.3](https://github.com/ZeroAlloc-Net/ZeroAlloc.Validation/compare/v0.2.2...v0.2.3) (2026-03-22)
 
 


### PR DESCRIPTION
## Summary
Promote the package to the 1.0 stability milestone.

Part of an ecosystem-wide campaign promoting all sub-1.0 ZeroAlloc packages to 1.0.0.

## Mechanism
The merge commit footer `Release-As: 1.0.0` instructs release-please to release as 1.0.0.

Release-As: 1.0.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)