### PR TITLE
ci: remove auto-publish to nuget on every main push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,10 +49,6 @@ jobs:
           dotnet pack src/ZeroAlloc.Validation.AspNetCore.Generator/ZeroAlloc.Validation.AspNetCore.Generator.csproj --no-build -c Release -p:PackageVersion=${{ steps.gitversion.outputs.version }} -o ./artifacts
           dotnet pack src/ZeroAlloc.Validation.Testing/ZeroAlloc.Validation.Testing.csproj --no-build -c Release -p:PackageVersion=${{ steps.gitversion.outputs.version }} -o ./artifacts
 
-      - name: Push to NuGet (pre-release)
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        run: dotnet nuget push ./artifacts/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
-
   api-compat:
     uses: ZeroAlloc-Net/.github/.github/workflows/api-compat.yml@main
     with:


### PR DESCRIPTION
## Summary

Per org-wide decision: only release-please-shepherded releases should publish to NuGet. The auto-publish step was shipping all 5 sibling packages (ZeroAlloc.Validation, ZeroAlloc.Validation.Generator, ZeroAlloc.Validation.AspNetCore, ZeroAlloc.Validation.AspNetCore.Generator, ZeroAlloc.Validation.Testing) on every main push outside release-please's bookkeeping.

Removed the `Push to NuGet (pre-release)` step from `.github/workflows/ci.yml`. Build/pack remain intact for all 5 packages.

## Test plan

- [ ] CI runs build/test/pack steps successfully on this PR
- [ ] No `dotnet nuget push` invocation remains in the workflow
- [ ] After merge, future pushes to main no longer publish pre-release packages