### PR TITLE
ci: switch release-please to manifest mode

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,7 +20,8 @@ jobs:
         uses: googleapis/release-please-action@v4
         id: release
         with:
-          release-type: simple
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json
           token: ${{ secrets.GITHUB_TOKEN }}
 
   publish:

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,9 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "packages": {
     ".": {
-      "release-type": "simple",
-      "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true
+      "release-type": "simple"
     }
   },
   "changelog-sections": [


### PR DESCRIPTION
## Summary

- Replace the inline `release-type: simple` input on `googleapis/release-please-action@v4` with explicit `config-file` + `manifest-file` inputs so the action runs in manifest mode and honours the committed config and manifest. Same root cause and fix as ZeroAlloc.Mediator PR #68.
- Strip pre-major flags (`bump-minor-pre-major`, `bump-patch-for-minor-pre-major`) from `release-please-config.json`. Packages are already at 1.1.0 (post-1.0) so these flags are no-ops.
- Manifest already reads `{".": "1.1.0"}`, so no version edit needed.

## Root cause

When `release-type` is supplied directly to the action, release-please-action treats the workflow input as the source of truth and ignores `release-please-config.json` / `.release-please-manifest.json` entirely. That makes the committed config / manifest dead code and breaks manifest-driven version tracking. Switching to `config-file` + `manifest-file` puts the action into manifest mode.

## Config layout note

`release-please-config.json` is currently a **single-package** layout — only `.` is enumerated under `packages`, even though `.github/workflows/release-please.yml` packs **7 NuGet packages in lockstep** from one version (`ZeroAlloc.Validation`, `.Generator`, `.AspNetCore`, `.AspNetCore.Generator`, `.Testing`, `.Inject`, `.Options`).

Converting to a true multi-package manifest layout (with each csproj enumerated and an `extra-files` strategy that fans out a single bumped version) is a larger follow-up. This PR only restores manifest-mode behaviour for the existing single-package layout.

## Diff

```yaml
# .github/workflows/release-please.yml
- release-type: simple
+ config-file: release-please-config.json
+ manifest-file: .release-please-manifest.json
```

```json
// release-please-config.json
"." : {
-  "release-type": "simple",
-  "bump-minor-pre-major": true,
-  "bump-patch-for-minor-pre-major": true
+  "release-type": "simple"
}
```

## Test plan

- [ ] After merge, observe the next `release-please` workflow run on `main`. It should open / update a release PR that reads the current version from `.release-please-manifest.json` (`1.1.0`) and proposes the next bump based on conventional commits since the last tag — without re-proposing 1.0.0 from scratch.
- [ ] Confirm no extra release PR churn (e.g. duplicate PRs from manifest vs inline modes fighting each other).
- [ ] Follow-up issue: convert config to multi-package manifest layout covering all 7 csproj packages.