### PR TITLE
fix(readme): absolute GitHub URLs so nuget.org links resolve

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ if (!result.IsValid)
 | Nested model     |             10.1 ns  |         619 ns   |  ~61×   |        0 B         |
 | Collection (3×)  |             14.3 ns  |        2,043 ns  | ~143×   |        0 B         |
 
-See [Performance](docs/performance.md) for full benchmark results.
+See [Performance](https://github.com/ZeroAlloc-Net/ZeroAlloc.Validation/blob/main/docs/performance.md) for full benchmark results.
 
 ## Packages
 
@@ -78,15 +78,15 @@ See [Performance](docs/performance.md) for full benchmark results.
 
 ## Documentation
 
-- [Getting Started](docs/getting-started.md)
-- [Attribute Reference](docs/attributes.md)
-- [Nested Validation](docs/nested-validation.md)
-- [Collection Validation](docs/collection-validation.md)
-- [Custom Validation](docs/custom-validation.md)
-- [Error Messages](docs/error-messages.md)
-- [ASP.NET Core Integration](docs/aspnetcore.md)
-- [DI Registration (Inject)](docs/inject.md)
-- [Options Validation](docs/options.md)
-- [Testing](docs/testing.md)
-- [Performance](docs/performance.md)
-- [Advanced Features](docs/advanced.md)
+- [Getting Started](https://github.com/ZeroAlloc-Net/ZeroAlloc.Validation/blob/main/docs/getting-started.md)
+- [Attribute Reference](https://github.com/ZeroAlloc-Net/ZeroAlloc.Validation/blob/main/docs/attributes.md)
+- [Nested Validation](https://github.com/ZeroAlloc-Net/ZeroAlloc.Validation/blob/main/docs/nested-validation.md)
+- [Collection Validation](https://github.com/ZeroAlloc-Net/ZeroAlloc.Validation/blob/main/docs/collection-validation.md)
+- [Custom Validation](https://github.com/ZeroAlloc-Net/ZeroAlloc.Validation/blob/main/docs/custom-validation.md)
+- [Error Messages](https://github.com/ZeroAlloc-Net/ZeroAlloc.Validation/blob/main/docs/error-messages.md)
+- [ASP.NET Core Integration](https://github.com/ZeroAlloc-Net/ZeroAlloc.Validation/blob/main/docs/aspnetcore.md)
+- [DI Registration (Inject)](https://github.com/ZeroAlloc-Net/ZeroAlloc.Validation/blob/main/docs/inject.md)
+- [Options Validation](https://github.com/ZeroAlloc-Net/ZeroAlloc.Validation/blob/main/docs/options.md)
+- [Testing](https://github.com/ZeroAlloc-Net/ZeroAlloc.Validation/blob/main/docs/testing.md)
+- [Performance](https://github.com/ZeroAlloc-Net/ZeroAlloc.Validation/blob/main/docs/performance.md)
+- [Advanced Features](https://github.com/ZeroAlloc-Net/ZeroAlloc.Validation/blob/main/docs/advanced.md)


### PR DESCRIPTION
## Summary

Rewrite all relative links in `README.md` to absolute GitHub URLs. The README ships to nuget.org via `<PackageReadmeFile>`; nuget.org renders it in its own host context, so any `[text](docs/foo.md)` style links 404 on the package page today.

## Pattern

- File links: `[text](path)` -> `[text](https://github.com/ZeroAlloc-Net/<repo>/blob/main/path)`
- Directory links: `[text](path/)` -> `[text](https://github.com/ZeroAlloc-Net/<repo>/tree/main/path/)`
- Image links: `![alt](img.png)` -> `![alt](https://raw.githubusercontent.com/ZeroAlloc-Net/<repo>/main/img.png)` (raw host so the image renders inline)
- Anchors (`#section`) and already-absolute URLs (`https://...`) unchanged
- `#anchor` fragments preserved on rewritten file links

## Verification

`README.md` still renders cleanly on the GitHub repo page (absolute self-references work in GitHub's renderer too). Once merged, the next NuGet release publishes the updated README and nuget.org links will resolve to the actual files.

Generated with [Claude Code](https://claude.com/claude-code)
