### PR TITLE
build(generator): publish ZeroAlloc.Validation.Generator as its own nupkg

### DIFF
--- a/src/ZeroAlloc.Validation.Generator/ZeroAlloc.Validation.Generator.csproj
+++ b/src/ZeroAlloc.Validation.Generator/ZeroAlloc.Validation.Generator.csproj
@@ -2,20 +2,73 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <RootNamespace>ZeroAlloc.Validation.Generator</RootNamespace>
+    <PackageId>ZeroAlloc.Validation.Generator</PackageId>
+    <Description>Roslyn source generator for ZeroAlloc.Validation. Emits the strongly-typed validator class for each [Validate]-annotated type at build time.</Description>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
     <IsRoslynComponent>true</IsRoslynComponent>
-    <IsPackable>false</IsPackable>
+
+    <!--
+      Source-generator packaging: ship the generator DLL under analyzers/dotnet/cs so
+      Roslyn loads it as an analyzer. Without IncludeBuildOutput=false the build output
+      ends up under lib/ and consumers silently get no source generator.
+    -->
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
+    <DevelopmentDependency>true</DevelopmentDependency>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="5.3.0" PrivateAssets="all" />
     <PackageReference Include="ZeroAlloc.Pipeline.Generators" Version="0.1.1" PrivateAssets="all" GeneratePathProperty="true" />
+    <PackageReference Include="ZeroAlloc.Pipeline" Version="0.1.1" PrivateAssets="all" GeneratePathProperty="true" />
   </ItemGroup>
 
   <ItemGroup>
     <AdditionalFiles Include="AnalyzerReleases.Shipped.md" />
     <AdditionalFiles Include="AnalyzerReleases.Unshipped.md" />
+  </ItemGroup>
+
+  <!--
+    Source generators run in an isolated context: Roslyn loads the generator DLL but does NOT
+    automatically load its package-reference dependencies. We work around this by emitting
+    the dependency DLLs next to the generator DLL so dotnet pack can place them under
+    analyzers/dotnet/cs alongside the generator itself.
+  -->
+  <Target Name="CopyGeneratorHelperDlls" AfterTargets="Build">
+    <ItemGroup>
+      <_GeneratorHelperDll Include="$(PkgZeroAlloc_Pipeline_Generators)\lib\netstandard2.0\ZeroAlloc.Pipeline.Generators.dll" />
+      <_GeneratorHelperDll Include="$(PkgZeroAlloc_Pipeline)\lib\netstandard2.0\ZeroAlloc.Pipeline.dll" />
+    </ItemGroup>
+    <Copy SourceFiles="@(_GeneratorHelperDll)"
+          DestinationFolder="$(OutputPath)"
+          SkipUnchangedFiles="true" />
+  </Target>
+
+  <!--
+    Pack the generator DLL (and its helper dependencies, which Roslyn must register as
+    additional analyzers) under analyzers/dotnet/cs. Without this, dotnet pack falls back
+    to the default lib/<tfm>/ layout and consumers do not pick up the generator at all.
+  -->
+  <ItemGroup>
+    <None Include="$(OutputPath)\$(AssemblyName).dll"
+          Pack="true"
+          PackagePath="analyzers/dotnet/cs"
+          Visible="false" />
+    <None Include="$(OutputPath)\$(AssemblyName).pdb"
+          Pack="true"
+          PackagePath="analyzers/dotnet/cs"
+          Visible="false"
+          Condition="Exists('$(OutputPath)\$(AssemblyName).pdb')" />
+    <None Include="$(OutputPath)\ZeroAlloc.Pipeline.Generators.dll"
+          Pack="true"
+          PackagePath="analyzers/dotnet/cs"
+          Visible="false" />
+    <None Include="$(OutputPath)\ZeroAlloc.Pipeline.dll"
+          Pack="true"
+          PackagePath="analyzers/dotnet/cs"
+          Visible="false" />
   </ItemGroup>
 
 </Project>

--- a/src/ZeroAlloc.Validation/ZeroAlloc.Validation.csproj
+++ b/src/ZeroAlloc.Validation/ZeroAlloc.Validation.csproj
@@ -19,14 +19,17 @@
     <AdditionalFiles Include="PublicAPI.Unshipped.txt" />
   </ItemGroup>
 
-  <!-- Bundle the source generator into this NuGet package -->
+  <!-- Run the source generator against THIS project's local build (so e.g. tests pick it up).
+       Consumer projects get the generator via the separate ZeroAlloc.Validation.Generator
+       nupkg (mirrors the ZeroAlloc.Mediator + ZeroAlloc.Mediator.Generator package split). -->
   <ItemGroup>
     <ProjectReference Include="..\ZeroAlloc.Validation.Generator\ZeroAlloc.Validation.Generator.csproj"
                       OutputItemType="Analyzer"
                       ReferenceOutputAssembly="false" />
   </ItemGroup>
 
-  <!-- Expose generator dependency DLLs as Analyzer items so Roslyn's loader can find them -->
+  <!-- Expose generator dependency DLLs as Analyzer items so Roslyn's loader finds them
+       during *this* project's build. -->
   <ItemGroup>
     <Analyzer Include="$(PkgZeroAlloc_Pipeline_Generators)\lib\netstandard2.0\ZeroAlloc.Pipeline.Generators.dll" />
     <Analyzer Include="$(PkgZeroAlloc_Pipeline)\lib\netstandard2.0\ZeroAlloc.Pipeline.dll" />


### PR DESCRIPTION
## Summary
Fixes the gap that the ZA.Templates \`za-clean\` template flagged: \`[Validate]\` attributes were decorative on the consumer side because the source generator was never packed into the published nupkg.

## Root cause
\`ZeroAlloc.Validation.Generator.csproj\` had \`<IsPackable>false</IsPackable>\` — the generator built locally (so this repo's tests + benchmarks worked) but no nupkg was ever produced. The main \`ZeroAlloc.Validation\` nupkg had \`analyzers/dotnet/cs/\` empty. Consumers got the attributes but no source generator.

## Fix
Mirrors the pattern in \`ZeroAlloc.Mediator\` + \`ZeroAlloc.Mediator.Generator\`:

- Remove \`IsPackable=false\` from \`ZeroAlloc.Validation.Generator.csproj\`
- Add standard analyzer-packaging metadata (\`IncludeBuildOutput=false\`, \`SuppressDependenciesWhenPacking=true\`, \`DevelopmentDependency=true\`)
- Add \`CopyGeneratorHelperDlls\` MSBuild target to stage \`ZeroAlloc.Pipeline.Generators.dll\` + \`ZeroAlloc.Pipeline.dll\` next to the generator (Roslyn doesn't auto-load generator dependencies from the package graph)
- Pack generator DLL + helper DLLs under \`analyzers/dotnet/cs/\`

## Verified locally
\`dotnet pack\` now produces a nupkg with this layout:
\`\`\`
analyzers/dotnet/cs/ZeroAlloc.Pipeline.Generators.dll
analyzers/dotnet/cs/ZeroAlloc.Pipeline.dll
analyzers/dotnet/cs/ZeroAlloc.Validation.Generator.dll
analyzers/dotnet/cs/ZeroAlloc.Validation.Generator.pdb
\`\`\`

All 800+ existing tests pass (\`dotnet test\` across net8.0 / net9.0 / net10.0 + Tests / Tests.AspNetCore / Tests.Inject / Tests.NUnit).

## Auto-publish
The existing \`publish-from-manifest.yml\` workflow walks \`src/*/*.csproj\` and packs every project (skips IsPackable=false). The new \`ZeroAlloc.Validation.Generator\` package will publish automatically on the next release-please version bump.

## Consumer usage after this ships
\`\`\`xml
<PackageReference Include="ZeroAlloc.Validation" />
<PackageReference Include="ZeroAlloc.Validation.Generator">
  <PrivateAssets>all</PrivateAssets>
  <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
</PackageReference>
\`\`\`

Then \`[Validate]\` actually generates the validator class. Once this is released, a follow-up PR against \`ZeroAlloc.Templates\` can replace the hand-rolled \`CreateOrderValidator\` with the attribute-based form.

## Test plan
- [x] \`dotnet pack src/ZeroAlloc.Validation.Generator/\` produces the expected layout
- [x] \`dotnet pack src/ZeroAlloc.Validation/\` still works
- [x] \`dotnet test\` green across all TFMs and all test projects
- [ ] Manual consumer-side test after the package publishes (covered by the follow-up ZA.Templates PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)