### PR TITLE
feat(generator): accept record declarations on top of class

### DIFF
--- a/src/ZeroAlloc.Validation.Generator/ValidatorGenerator.cs
+++ b/src/ZeroAlloc.Validation.Generator/ValidatorGenerator.cs
@@ -60,7 +60,10 @@ public sealed class ValidatorGenerator : IIncrementalGenerator
         var validateClasses = context.SyntaxProvider
             .ForAttributeWithMetadataName(
                 ValidateAttributeFqn,
-                predicate: static (node, _) => node is ClassDeclarationSyntax,
+                // Accept both classes and records (positional records are
+                // RecordDeclarationSyntax, not ClassDeclarationSyntax — the
+                // generator walks symbol properties identically for both).
+                predicate: static (node, _) => node is ClassDeclarationSyntax or RecordDeclarationSyntax,
                 transform: static (ctx, _) => (INamedTypeSymbol)ctx.TargetSymbol);
 
 #pragma warning disable EPS06 // IncrementalValuesProvider<T> is a struct; Combine is the standard Roslyn API

--- a/tests/ZeroAlloc.Validation.Tests/Integration/RecordValidationTests.cs
+++ b/tests/ZeroAlloc.Validation.Tests/Integration/RecordValidationTests.cs
@@ -1,0 +1,66 @@
+using Xunit;
+using ZeroAlloc.Validation;
+
+#pragma warning disable MA0048 // multiple types intentionally co-located with the test class
+
+namespace ZeroAlloc.Validation.Tests.Integration;
+
+// Records vs classes: the generator must accept both. Positional record params
+// translate to compiler-emitted properties, which the rule walker picks up via
+// IPropertySymbol enumeration — identical to the class path once past the
+// syntax predicate.
+
+[Validate]
+public sealed record AddressRecord(
+    [property: NotEmpty(Message = "Street is required.")] string Street,
+    [property: NotEmpty(Message = "City is required.")] string City);
+
+[Validate]
+public sealed record OrderRecord(
+    [property: GreaterThan(0)] int CustomerId,
+    [property: NotEmpty] string Sku,
+    [property: GreaterThanOrEqualTo(0)] decimal UnitPrice);
+
+public class RecordValidationTests
+{
+    [Fact]
+    public void AddressRecord_ValidInputs_PassesValidation()
+    {
+        var address = new AddressRecord(Street: "Main 1", City: "Amsterdam");
+        var result = new AddressRecordValidator().Validate(address);
+
+        Assert.True(result.IsValid);
+        Assert.True(result.Failures.IsEmpty);
+    }
+
+    [Fact]
+    public void AddressRecord_EmptyStreet_FailsValidation()
+    {
+        var address = new AddressRecord(Street: "", City: "Amsterdam");
+        var result = new AddressRecordValidator().Validate(address);
+
+        Assert.False(result.IsValid);
+        Assert.Equal(1, result.Failures.Length);
+        Assert.Equal("Street", result.Failures[0].PropertyName);
+        Assert.Equal("Street is required.", result.Failures[0].ErrorMessage);
+    }
+
+    [Fact]
+    public void OrderRecord_AllRulesEvaluated()
+    {
+        var order = new OrderRecord(CustomerId: 0, Sku: "", UnitPrice: -1m);
+        var result = new OrderRecordValidator().Validate(order);
+
+        Assert.False(result.IsValid);
+        Assert.Equal(3, result.Failures.Length);
+    }
+
+    [Fact]
+    public void OrderRecord_ValidInputs_PassesValidation()
+    {
+        var order = new OrderRecord(CustomerId: 42, Sku: "ABC", UnitPrice: 19.99m);
+        var result = new OrderRecordValidator().Validate(order);
+
+        Assert.True(result.IsValid);
+    }
+}


### PR DESCRIPTION
## Summary
Discovered while migrating the ZA.Templates \`za-clean\` template to use \`[Validate]\` on its \`CreateOrderCommand\` record: the generator's \`ForAttributeWithMetadataName\` predicate was \`node is ClassDeclarationSyntax\` — which silently excludes records. The generator package fix in #37 unblocked package consumers, but this predicate-skips-records bug was still hiding underneath.

## Root cause
Records are \`RecordDeclarationSyntax\` (a separate \`TypeDeclarationSyntax\` subclass), not \`ClassDeclarationSyntax\`. The downstream rule walker uses \`INamedTypeSymbol.GetMembers()\` to enumerate properties — that's identical for classes and records (positional record params surface as compiler-emitted properties).

So the fix is one line:

\`\`\`csharp
- predicate: static (node, _) => node is ClassDeclarationSyntax,
+ predicate: static (node, _) => node is ClassDeclarationSyntax or RecordDeclarationSyntax,
\`\`\`

## Test coverage
Adds \`RecordValidationTests\` with 4 scenarios:
- Positional record validates successfully on valid inputs
- Empty positional-param value produces the correct failure (right property name, right message)
- Multiple rules across multiple positional params all evaluate
- Mix of int/string/decimal positional params flows through

## Test plan
- [x] Build green
- [x] New \`RecordValidationTests\`: 4/4 passing across net8.0 / net9.0 / net10.0
- [x] Full existing suite: 268/268 + 6/6 + 5/5 + 4/4 = 800+ tests still passing
- [x] No public API change

🤖 Generated with [Claude Code](https://claude.com/claude-code)