### PR TITLE
feat(generator): [Validate] now accepts struct and record struct

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1,0 +1,70 @@
+# ZeroAlloc.Validation — Backlog
+
+Candidate enhancements identified during real-world usage. Each item is independent and can be implemented in any order. Order is rough priority, not commitment. Items graduate from this backlog when the friction or value is concrete enough to justify the work.
+
+---
+
+## B1 — Value-object aware property validators
+
+**What.** Teach the `[Validate]` generator to recognize properties whose declared type is a `ZeroAlloc.ValueObjects` `[ValueObject]` partial struct, and emit comparison/range/predicate validators (`[GreaterThan]`, `[LessThan]`, `[InRange]`, `[NotEmpty]`, …) against the unwrapped underlying value rather than the wrapper. So this becomes legal:
+
+```csharp
+[Validate]
+public readonly record struct PlaceOrderCommand(
+    [property: GreaterThan(0)] CustomerId CustomerId,
+    [property: GreaterThan(0)] decimal Total)
+    : IRequest<Result<OrderId, Error>>;
+```
+
+Today the generator can only emit a `>` against a primitive — a `CustomerId` wrapping an `int` doesn't satisfy the comparison, so the request must be modelled with `int CustomerId` and the handler manually wraps to `new CustomerId(...)`. This weakens the request-side type signal exactly where validation should be reinforcing it.
+
+**Why.** Friction surfaced 2026-05-26 building the `za-vertical-slice` template's `PlaceOrder` slice (ZeroAlloc.Templates 0.4.0). The vertical-slice idiom pushes hard on "request type IS the contract"; being forced to fall back to raw `int` for any property that participates in validation undermines that. The same pattern almost certainly hits every consumer that combines `[Validate]` with `[ValueObject]`-typed identifiers.
+
+**Sketch.** During property resolution in the generator:
+
+- If the property type is a struct from a referenced compilation with `[ValueObject]` (or shape: partial struct with a single readable `Value` property of comparable primitive type plus a matching constructor),
+- treat the property as the underlying primitive for the purposes of emitting validator comparisons,
+- emit `prop.Value` (or the resolved member name) as the comparable target.
+
+Non-comparable / multi-field value-objects (e.g. `Money(Amount, Currency)`) fall back to the existing predicate-validator path; only single-primitive wrappers participate.
+
+**Tradeoff / risks.**
+
+- Couples `ZeroAlloc.Validation`'s generator to the generated shape of `ZeroAlloc.ValueObjects`. A future ValueObjects rename of `Value` or a layout change could silently break this. Two mitigations to evaluate at design time:
+  - (a) duck-type on "single public readable property whose type matches the validator's comparison target" — robust to attribute renames, but matches accidentally on unrelated structs;
+  - (b) detect `[ValueObject]` by metadata name and read a generator-emitted marker attribute on the unwrap member — tighter coupling, but explicit.
+- Bigger alternative (option B from the brainstorm): push invariants into `ZeroAlloc.ValueObjects` itself (`[Positive]` on the partial struct → guarded ctor). Stronger correctness story but a much larger API change, and conflicts with EF Core "construct-with-sentinel, DB picks id" patterns (`new OrderId(0)` would fail at construction). This backlog item deliberately scopes to the lighter-touch option.
+
+**Graduation signal.** A second consumer codebase hits the same papercut, OR `za-vertical-slice` reaches v1 and the workaround (raw primitive in request, wrap in handler) is judged too lossy to ship as the documented convention.
+
+---
+
+## B2 — `[Validate]` on `record`, `record struct`, and `struct` targets
+
+**What.** Allow `[Validate]` to decorate `record` (class) **and** `struct` / `record struct` declarations, not just `class`. Today the attribute is declared with `AttributeTargets.Class`, so:
+
+```csharp
+[Validate]
+public readonly record struct PlaceOrderCommand(             // CS0592
+    [property: GreaterThan(0)] int CustomerId,
+    [property: GreaterThan(0)] decimal Total);
+```
+
+…produces `CS0592: Attribute 'Validate' is not valid on this declaration type. It is only valid on 'class' declarations.` `sealed record` (record class) compiles, but `record struct` and plain `struct` do not. The generator itself almost certainly produces correct validator code for any of these shapes — the restriction is at the attribute-target level.
+
+**Why.** Friction surfaced 2026-05-26 building the `za-vertical-slice` template's `PlaceOrder` / `GetOrder` / `ListOrders` / `CancelOrder` slices (ZeroAlloc.Templates 0.4.0). The vertical-slice idiom prefers request types as `readonly record struct` for the small-allocation story; being forced to widen them to `sealed record` (class) for the sole reason of attaching `[Validate]` is exactly the kind of papercut that erodes the "ZeroAlloc" promise at the entry-point of the pipeline. Same pattern hits anyone building allocation-sensitive request types (high-throughput message handlers, hot-path command dispatch).
+
+**Sketch.**
+
+- Change the `[Validate]` `AttributeUsage` to `AttributeTargets.Class | AttributeTargets.Struct`. C# treats `record` and `record struct` as class / struct respectively, so this single change unlocks all four shapes.
+- Audit the generator for any code that assumes the target is a class (e.g. `: TypeKind.Class`-only checks, nullability of the validated instance). For `struct` / `record struct`, instances are non-nullable by value semantics — the generated validator probably already handles this correctly, but a snapshot test should pin it.
+- Add four positive snapshot tests covering each shape (`class`, `record`, `struct`, `record struct`) so the convention is locked in.
+
+**Tradeoff / risks.**
+
+- **Mutability surprise on plain `struct`.** A non-`readonly` `struct` can be mutated between the validator running and the handler reading it (defensive-copy rules). Best-practice guidance in the docs: prefer `readonly struct` or `readonly record struct` when pairing with `[Validate]`. Could fire a soft diagnostic (`ZAVAL_???`) when `[Validate]` decorates a non-readonly struct, similar to how Roslyn warns on mutable readonly-context misuse.
+- **Generator API surface.** If the generator currently emits `static ClassNameValidator { ... }` with a class-only contract (e.g. takes `T?` nullable reference for the input), struct support needs a small adapter or a duplicate code path. Should be straightforward — pin with the snapshot tests above.
+
+**Graduation signal.** A second `[Validate]`-using codebase requests struct / record-struct support, OR `za-vertical-slice` reaches v1 with `sealed record` as the documented request shape and the team judges the loss of `readonly record struct` ergonomics too high to ship as the convention.
+
+**Relationship to B1.** Independent. B1 unlocks value-object properties; B2 unlocks struct-shaped requests. Same template surfaced both; either can ship first.

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -70,12 +70,12 @@ public IEnumerable<ValidationFailure> ValidateBusinessRules()
 
 **Title:** `[Validate]` on non-readonly struct
 
-**What it means.** You decorated a `struct` or `record struct` with `[Validate]`,
+**When fired:** You decorated a `struct` or `record struct` with `[Validate]`,
 but the type is not declared `readonly`. A caller can mutate the instance
 between the validator returning `IsValid == true` and the consumer reading
 the value — making the validation result stale.
 
-**Fix.** Declare the type as `readonly struct` or `readonly record struct`:
+**Fix:** Declare the type as `readonly struct` or `readonly record struct`:
 
 ```csharp
 [Validate]
@@ -84,7 +84,7 @@ public readonly record struct PlaceOrderCommand(
     [property: GreaterThan(0)] decimal Total);
 ```
 
-**Suppressing.** If your call site cooperates with the hazard (e.g. you validate
+**Suppressing:** If your call site cooperates with the hazard (e.g. you validate
 inside the same method that constructs the struct and never mutate after),
 suppress with `#pragma warning disable ZV0014` around the type declaration,
 or add `<NoWarn>$(NoWarn);ZV0014</NoWarn>` in the consuming project.

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -15,9 +15,8 @@ ZeroAlloc.Validation.Generator emits the following Roslyn diagnostics at compile
 | [ZV0011](#zv0011) | Warning | Redundant [ValidateWith] attribute |
 | [ZV0012](#zv0012) | Error | Invalid [ValidateWith] validator type |
 | [ZV0013](#zv0013) | Error | Invalid [CustomValidation] method signature |
+| [ZV0014](#zv0014) | Warning | [Validate] on non-readonly struct |
 | [ZV0015](#zv0015) | Error | Duplicate pipeline behavior Order |
-
-> **Note:** ZV0014 is reserved for a planned future diagnostic ("async-only behavior used with sync-only call site") and is not yet emitted.
 
 ---
 
@@ -62,6 +61,33 @@ public IEnumerable<ValidationFailure> ValidateBusinessRules()
     // yield return failures as needed
 }
 ```
+
+---
+
+## ZV0014
+
+**Severity:** Warning
+
+**Title:** `[Validate]` on non-readonly struct
+
+**What it means.** You decorated a `struct` or `record struct` with `[Validate]`,
+but the type is not declared `readonly`. A caller can mutate the instance
+between the validator returning `IsValid == true` and the consumer reading
+the value — making the validation result stale.
+
+**Fix.** Declare the type as `readonly struct` or `readonly record struct`:
+
+```csharp
+[Validate]
+public readonly record struct PlaceOrderCommand(
+    [property: GreaterThan(0)] int CustomerId,
+    [property: GreaterThan(0)] decimal Total);
+```
+
+**Suppressing.** If your call site cooperates with the hazard (e.g. you validate
+inside the same method that constructs the struct and never mutate after),
+suppress with `#pragma warning disable ZV0014` around the type declaration,
+or add `<NoWarn>$(NoWarn);ZV0014</NoWarn>` in the consuming project.
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -58,6 +58,12 @@ public class RegisterUserRequest
 
 The generator emits `RegisterUserRequestValidator` in the same namespace as your model. For flat models like this one (no nested validated properties), the generated validator has a parameterless constructor.
 
+> **Target types.** `[Validate]` works on `class`, `record`, `readonly struct`, and
+> `readonly record struct`. Decorating a non-readonly `struct` or `record struct`
+> emits `ZV0014` (Warning) — a caller can mutate the instance between the
+> validator returning success and the consumer reading the value, making the
+> validation result stale. Prefer the `readonly` form for request types.
+
 ## Call the validator
 
 Instantiate the generated validator and call `Validate`. The returned `ValidationResult` exposes `IsValid` and a zero-allocation `Failures` span:

--- a/docs/plans/2026-05-27-validate-struct-target-design.md
+++ b/docs/plans/2026-05-27-validate-struct-target-design.md
@@ -1,0 +1,188 @@
+# `[Validate]` on `struct` / `record struct` — Design
+
+**Date:** 2026-05-27
+**Scope:** Widen the `[Validate]` attribute target from `Class` to `Class | Struct`, extend the source generator's syntax predicate to match `StructDeclarationSyntax` / `RecordStructDeclarationSyntax`, and emit `ZV0014` as a Warning when `[Validate]` decorates a non-readonly struct. Closes backlog item B2 in `docs/backlog.md`. Ships as **ZeroAlloc.Validation 1.3.0** (additive minor — existing class/record consumers see no behaviour change).
+
+## Background
+
+`ValidateAttribute` ships with `AttributeUsage(AttributeTargets.Class)`. C# encodes `class` and `record` as `Class`, but `struct` and `record struct` as `Struct`. As a result, `[Validate]` rejects struct-shaped request types with **CS0592: Attribute 'Validate' is not valid on this declaration type. It is only valid on 'class' declarations.**
+
+This surfaced 2026-05-26 while building the `za-vertical-slice` template (ZeroAlloc.Templates 0.7.0). The vertical-slice idiom prefers `readonly record struct` request types for the zero-allocation story; the template's four request types had to be widened to `sealed record` (class) for the sole reason of attaching `[Validate]`. That widening costs the per-request stack-allocation savings the struct form would deliver. The same pattern hits any allocation-sensitive consumer pairing `[Validate]` with hot-path command dispatch.
+
+The downstream generator (`ValidatorGenerator.cs` + `RuleEmitter.cs`) walks `INamedTypeSymbol.GetMembers()` for properties and emits `Validate(T instance)` against the named symbol. The walk is `TypeKind`-agnostic — once the attribute target accepts structs, the existing emission paths produce a working validator with no further changes.
+
+## Goal
+
+`[Validate]` decorates all four C# shapes — `class`, `record`, `struct`, `record struct` — and the source generator emits a working `XValidator : ValidatorFor<X>` for each. Non-readonly structs raise `ZV0014` (Warning) to flag the staleness hazard (a caller can mutate the instance after validation returns success and before the consumer reads it).
+
+## Decisions
+
+### D-1: target widening — `Class | Struct`, not gated by `readonly`
+
+Accept all four shapes. Restricting `[Validate]` to `readonly struct` / `readonly record struct` via a hard refusal in the generator would be paternalistic for a v1.x minor bump — legitimate uses exist (builder-style mutable structs frozen by a wrapper before validation, or short-lived in-method validation where mutation isn't possible). The warning (D-3) gives the loud signal at compile time without blocking the build.
+
+**Considered and rejected:**
+
+- **`Class | Struct` restricted to `readonly` structs only** (hard error on non-readonly). Safer but blocks legitimate cases and converts a Warning-grade hazard into a build-stopping rule. Rejected.
+- **`Struct` only when `readonly`** — same shape as above but enforced via an analyzer check that fails before emission. Same issue, same rejection.
+
+### D-2: validator method signature — pass-by-value, no new overload
+
+Keep the existing `ValidatorFor<T>.Validate(T instance)` signature. The generator emits the same `public override ValidationResult Validate(T instance)` for all four shapes. For struct T this means a defensive copy on every call.
+
+**Why:** the "ZeroAlloc" promise is about **heap** allocations, not struct copies. Request structs typical of `[Validate]` consumers are small (the `za-vertical-slice` PlaceOrderCommand is `(int CustomerId, decimal Total)` = 20 bytes); the stack copy is below noise on the measured allocation profile (Validator_Generated benchmark at 2.18 ns / 0 B). Adding an `in T` overload to `ValidatorFor<T>` would expand the public surface for theoretical wins that aren't currently load-bearing.
+
+**Considered and rejected:**
+
+- **Add `Validate(in T)` to `ValidatorFor<T>`.** Generator emits `in T` for struct T, plain T for class T. Saves the copy but expands the abstract base's API. Deferrable — if a future consumer measures the copy cost as load-bearing, ship it then as a 1.4.x minor.
+- **Don't derive from `ValidatorFor<T>` for structs.** Generator emits a free-standing sealed validator with `Validate(in T)` for struct T. Cleanest signature but sacrifices polymorphism (validators can no longer be stored in a `Dictionary<Type, ValidatorFor<>>`-style registry). Rejected.
+
+### D-3: non-readonly struct fires `ZV0014` Warning
+
+New diagnostic descriptor in `ValidatorGenerator.cs`:
+
+- ID: `ZV0014` (fills the gap between shipped `ZV0013` and `ZV0015`)
+- Category: `ZeroAlloc.Validation`
+- Severity: `Warning` (build-visible, opt-out via `#pragma warning disable ZV0014` or `<NoWarn>$(NoWarn);ZV0014</NoWarn>`)
+- Title: "[Validate] on non-readonly struct"
+- Message: "Struct '{0}' is decorated with [Validate] but is not declared `readonly`. A caller can mutate the instance between the validator returning success and the consumer reading the value, making validation results stale. Declare the struct as `readonly struct` or `readonly record struct`."
+
+Fires during `RegisterSourceOutput` after resolving `INamedTypeSymbol`, when `TypeKind == Struct && !IsReadOnly`. Generator still emits the validator — warning is a soft signal, not a refusal.
+
+**Why Warning, not Error or Info:**
+
+- **Warning** gets caught at PR review (visible in CI logs and IDE), opt-out via single-line pragma when the consumer cooperates with the hazard.
+- **Error** is paternalistic for a v1.x minor; blocks legitimate cases (D-1 rationale).
+- **Info** loses CI visibility — IDE-only signal that's easy to miss in code review.
+
+## Design
+
+### Files touched
+
+- `src/ZeroAlloc.Validation/Attributes/ValidateAttribute.cs` — widen `AttributeTargets.Class` to `AttributeTargets.Class | AttributeTargets.Struct`.
+- `src/ZeroAlloc.Validation.Generator/ValidatorGenerator.cs` — widen the `ForAttributeWithMetadataName` predicate to also match `StructDeclarationSyntax` / `RecordStructDeclarationSyntax`; add the `ZV0014` `DiagnosticDescriptor`; emit the warning conditionally during `RegisterSourceOutput`.
+- `src/ZeroAlloc.Validation.Generator/AnalyzerReleases.Unshipped.md` — add the `ZV0014` row.
+- `tests/ZeroAlloc.Validation.Tests/Integration/StructValidationTests.cs` (NEW) — 4 integration `[Fact]`s covering `readonly struct` + `readonly record struct` happy/sad paths.
+- `tests/ZeroAlloc.Validation.Tests/Generator/StructValidationDiagnosticTests.cs` (NEW) — 5 generator-level diagnostic tests covering the matrix of shape × readonly-ness.
+- `docs/getting-started.md` — callout that `[Validate]` accepts `class` / `record` / `readonly struct` / `readonly record struct`, with the `ZV0014` warning for non-readonly structs.
+- `docs/error-messages.md` — `ZV0014` section: hazard description + fix (`readonly struct`).
+- `docs/backlog.md` — mark B2 ✅ shipped (1.3.0) on release-PR merge.
+
+### Attribute target
+
+```csharp
+// src/ZeroAlloc.Validation/Attributes/ValidateAttribute.cs
+namespace ZeroAlloc.Validation;
+
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct, AllowMultiple = false)]
+public sealed class ValidateAttribute : Attribute
+{
+    public bool StopOnFirstFailure { get; set; }
+}
+```
+
+### Generator syntax predicate
+
+```csharp
+// src/ZeroAlloc.Validation.Generator/ValidatorGenerator.cs (Initialize)
+var validateClasses = context.SyntaxProvider
+    .ForAttributeWithMetadataName(
+        ValidateAttributeFqn,
+        // All four C# shapes — class, record (class), struct, record struct —
+        // hit the same emission path; the downstream generator walks symbol
+        // properties identically regardless of TypeKind.
+        predicate: static (node, _) =>
+            node is ClassDeclarationSyntax
+                 or RecordDeclarationSyntax
+                 or StructDeclarationSyntax
+                 or RecordStructDeclarationSyntax,
+        transform: static (ctx, _) => (INamedTypeSymbol)ctx.TargetSymbol);
+```
+
+### `ZV0014` diagnostic
+
+```csharp
+// src/ZeroAlloc.Validation.Generator/ValidatorGenerator.cs
+private static readonly DiagnosticDescriptor ZV0014 = new DiagnosticDescriptor(
+    id: "ZV0014",
+    title: "[Validate] on non-readonly struct",
+    messageFormat:
+        "Struct '{0}' is decorated with [Validate] but is not declared `readonly`. " +
+        "A caller can mutate the instance between the validator returning success " +
+        "and the consumer reading the value, making validation results stale. " +
+        "Declare the struct as `readonly struct` or `readonly record struct`.",
+    category: "ZeroAlloc.Validation",
+    defaultSeverity: DiagnosticSeverity.Warning,
+    isEnabledByDefault: true);
+```
+
+Reported during the `RegisterSourceOutput` callback (after `ForAttributeWithMetadataName` resolves the symbol):
+
+```csharp
+if (symbol.TypeKind == TypeKind.Struct && !symbol.IsReadOnly)
+{
+    ctx.ReportDiagnostic(Diagnostic.Create(
+        ZV0014,
+        symbol.Locations.FirstOrDefault() ?? Location.None,
+        symbol.Name));
+}
+```
+
+Generator emission proceeds regardless — the warning is informational.
+
+### Test surface
+
+**Integration** (`StructValidationTests.cs`): four `[Fact]`s — two shapes × happy / sad paths. Inline model declarations:
+
+```csharp
+[Validate]
+public readonly record struct RrsCommand([property: GreaterThan(0)] int Total);
+
+[Validate]
+public readonly struct RsCommand
+{
+    public int Total { get; }
+    public RsCommand(int total) => Total = total;
+}
+```
+
+Assertions: `Validate` returns `IsValid == true` for valid input; `IsValid == false` + `Failures[0].PropertyName == "Total"` for invalid.
+
+**Generator diagnostic** (`StructValidationDiagnosticTests.cs`): five cases, snapshot pattern following `GeneratorDiscoveryTests.cs`:
+
+| Source | Expected diagnostics |
+|---|---|
+| `[Validate] readonly record struct X(...)` | none |
+| `[Validate] readonly struct X { ... }` | none |
+| `[Validate] record struct X(...)` | `ZV0014` |
+| `[Validate] struct X { ... }` | `ZV0014` |
+| `[Validate] class X { ... }` | none (regression net) |
+
+**Existing tests** (class + record) act as the regression net for the legacy paths — no edits needed.
+
+### Backward compatibility
+
+Strictly additive:
+
+- Existing `[Validate] class` / `[Validate] record` consumers see zero behaviour change.
+- `ZV0014` is a new diagnostic — by definition no existing code can have been emitting it.
+- `ValidatorFor<T>` base signature is unchanged (D-2).
+
+SemVer: minor bump (`1.2.0` → `1.3.0`).
+
+## Out of scope (deferred)
+
+- **`Validate(in T)` overload on `ValidatorFor<T>`** (D-2 alternative). Defer until a consumer measures the struct-copy cost as load-bearing.
+- **Value-object-aware property validators** — backlog B1, separate brainstorm session, separate 1.x minor.
+- **Migrating the `za-vertical-slice` template's request types from `sealed record` back to `readonly record struct`.** Happens in `ZeroAlloc.Templates` after 1.3.0 propagates to NuGet — separate PR there.
+
+## Files touched (final count)
+
+- **MOD:** 1 attribute file
+- **MOD:** 1 generator file (+1 descriptor + diagnostic report)
+- **MOD:** 1 analyzer-release manifest
+- **NEW:** 2 test files (~9 tests total)
+- **MOD:** 2 doc files (getting-started + error-messages)
+- **MOD:** `docs/backlog.md` (mark B2 shipped on release)
+
+Total commit footprint: ~250 LOC including tests.

--- a/docs/plans/2026-05-27-validate-struct-target.md
+++ b/docs/plans/2026-05-27-validate-struct-target.md
@@ -1,0 +1,679 @@
+# `[Validate]` struct target — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Ship ZeroAlloc.Validation 1.3.0 widening `[Validate]` from `Class` to `Class | Struct`, with `ZV0014` (Warning) firing on non-readonly structs.
+
+**Architecture:** Two-line attribute change + four-token generator predicate widening + one new `DiagnosticDescriptor`. The existing rule-emission paths are `TypeKind`-agnostic and require no edits. Closes backlog B2.
+
+**Tech Stack:** .NET 10, Roslyn incremental generator (`IIncrementalGenerator`), xUnit, `AnalyzerReleases.Unshipped.md`.
+
+**Design doc:** `docs/plans/2026-05-27-validate-struct-target-design.md` (committed at `13f5c0b`).
+
+**Working branch:** `feat/validate-struct-target` (already created off `main`; design committed).
+
+---
+
+## Phase 0 — Orientation (5 min)
+
+Before touching code, skim three files so the rest of the plan reads in context. No commits in this phase.
+
+### Task 0.1: Read the existing attribute + generator entry
+
+**Files (read-only):**
+- `src/ZeroAlloc.Validation/Attributes/ValidateAttribute.cs` — current `AttributeTargets.Class`. The single line to change.
+- `src/ZeroAlloc.Validation.Generator/ValidatorGenerator.cs:58-78` — `Initialize` registers the `ForAttributeWithMetadataName` pipeline. Line 66's predicate is the syntax-node filter.
+- `src/ZeroAlloc.Validation.Generator/ValidatorGenerator.cs:81` — the `Emit` method runs per matched symbol. `ZV0014` reporting hooks in here.
+- `src/ZeroAlloc.Validation.Generator/ValidatorGenerator.cs:26-56` — existing `DiagnosticDescriptor` declarations (`ZV0011 / ZV0012 / ZV0013 / ZV0015`). `ZV0014` follows the same shape and slots in to fill the gap.
+
+### Task 0.2: Read one existing integration test + one existing generator test
+
+**Files (read-only):**
+- `tests/ZeroAlloc.Validation.Tests/Integration/EndToEndTests.cs` — see how integration tests instantiate `XValidator` directly and assert on `ValidationResult`. The new struct tests follow this exact shape.
+- `tests/ZeroAlloc.Validation.Tests/Generator/GeneratorDiscoveryTests.cs` — see how generator tests construct a `CSharpCompilation`, run the generator, and inspect `Diagnostics` / `GeneratedTrees`. The `ZV0014` tests follow this shape.
+
+---
+
+## Phase 1 — Widen attribute target via failing test (TDD) (30 min, 5 tasks)
+
+### Task 1.1: Write the failing integration test for `readonly record struct`
+
+**Files:**
+- Create: `tests/ZeroAlloc.Validation.Tests/Integration/StructValidationTests.cs`
+
+**Step 1: Write the test file**
+
+```csharp
+using Xunit;
+using ZeroAlloc.Validation;
+
+namespace ZeroAlloc.Validation.Tests.Integration;
+
+public class StructValidationTests
+{
+    [Fact]
+    public void ReadonlyRecordStruct_Validate_HappyPath_ReportsValid()
+    {
+        var validator = new RrsCommandValidator();
+        var result = validator.Validate(new RrsCommand(Total: 10));
+        Assert.True(result.IsValid);
+    }
+
+    [Fact]
+    public void ReadonlyRecordStruct_Validate_SadPath_ReportsFailureOnTotal()
+    {
+        var validator = new RrsCommandValidator();
+        var result = validator.Validate(new RrsCommand(Total: 0));
+        Assert.False(result.IsValid);
+        Assert.Equal(nameof(RrsCommand.Total), result.Failures[0].PropertyName);
+    }
+}
+
+[Validate]
+public readonly record struct RrsCommand([property: GreaterThan(0)] int Total);
+```
+
+**Step 2: Run the test — expect BUILD FAIL**
+
+```bash
+cd c:/Projects/Prive/ZeroAlloc/ZeroAlloc.Validation
+dotnet build tests/ZeroAlloc.Validation.Tests -c Release
+```
+
+Expected: `CS0592: Attribute 'Validate' is not valid on this declaration type. It is only valid on 'class' declarations.`
+
+This is the gate — the test must fail-build for the same reason a real consumer fails today. If it builds, the attribute target was already widened or the test isn't applying it to a struct.
+
+**No commit yet** — test is failing.
+
+### Task 1.2: Widen `AttributeTargets` on `ValidateAttribute`
+
+**Files:**
+- Modify: `src/ZeroAlloc.Validation/Attributes/ValidateAttribute.cs`
+
+**Step 1: Change the `[AttributeUsage]` flags**
+
+```csharp
+namespace ZeroAlloc.Validation;
+
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct, AllowMultiple = false)]
+public sealed class ValidateAttribute : Attribute
+{
+    public bool StopOnFirstFailure { get; set; }
+}
+```
+
+**Step 2: Build the attribute project**
+
+```bash
+dotnet build src/ZeroAlloc.Validation -c Release
+```
+
+Expected: build succeeds, no warnings.
+
+**Step 3: Build the test project — expect BUILD STILL FAILS, but with a different error**
+
+```bash
+dotnet build tests/ZeroAlloc.Validation.Tests -c Release
+```
+
+Expected: `CS0246: The type or namespace name 'RrsCommandValidator' could not be found`. The attribute now accepts the struct target, but the generator hasn't emitted the validator class. This is the next gate.
+
+**No commit yet** — generator widening is the same logical unit of work.
+
+### Task 1.3: Widen the generator's syntax-node predicate
+
+**Files:**
+- Modify: `src/ZeroAlloc.Validation.Generator/ValidatorGenerator.cs` (around line 66)
+
+**Step 1: Replace the predicate**
+
+Find:
+
+```csharp
+predicate: static (node, _) => node is ClassDeclarationSyntax or RecordDeclarationSyntax,
+```
+
+Replace with:
+
+```csharp
+// All four C# shapes — class, record (class), struct, record struct — hit
+// the same emission path; the downstream generator walks symbol properties
+// identically regardless of TypeKind.
+predicate: static (node, _) =>
+    node is ClassDeclarationSyntax
+         or RecordDeclarationSyntax
+         or StructDeclarationSyntax
+         or RecordStructDeclarationSyntax,
+```
+
+`StructDeclarationSyntax` and `RecordStructDeclarationSyntax` are already reachable via the existing `using Microsoft.CodeAnalysis.CSharp.Syntax;` at the top of the file — no new `using` needed.
+
+**Step 2: Build the generator**
+
+```bash
+dotnet build src/ZeroAlloc.Validation.Generator -c Release
+```
+
+Expected: build succeeds.
+
+### Task 1.4: Run the failing test — now expect PASS
+
+```bash
+cd c:/Projects/Prive/ZeroAlloc/ZeroAlloc.Validation
+dotnet test tests/ZeroAlloc.Validation.Tests -c Release --filter "FullyQualifiedName~StructValidationTests"
+```
+
+Expected: 2/2 pass (`ReadonlyRecordStruct_Validate_HappyPath_ReportsValid`, `ReadonlyRecordStruct_Validate_SadPath_ReportsFailureOnTotal`).
+
+If `CS0246` still fires, the generator's incremental cache is stale — run `dotnet build --no-incremental tests/ZeroAlloc.Validation.Tests` to force a fresh pipeline.
+
+### Task 1.5: Run the full test suite — verify no regressions
+
+```bash
+dotnet test -c Release
+```
+
+Expected: every existing test passes. The `class` / `record` paths are unchanged; the new predicate is purely additive.
+
+### Task 1.6: Commit
+
+```bash
+git add src/ZeroAlloc.Validation/Attributes/ValidateAttribute.cs \
+        src/ZeroAlloc.Validation.Generator/ValidatorGenerator.cs \
+        tests/ZeroAlloc.Validation.Tests/Integration/StructValidationTests.cs
+git commit -m "feat(generator): [Validate] now accepts readonly record struct
+
+Widens AttributeTargets.Class to Class | Struct on ValidateAttribute
+and adds StructDeclarationSyntax / RecordStructDeclarationSyntax to the
+generator's syntax-node predicate. The downstream rule-emission paths
+already walked symbol properties TypeKind-agnostically, so accepting
+struct targets needed no further changes.
+
+Tests cover readonly record struct happy + sad paths; readonly struct
+(without record) and the non-readonly diagnostic land in follow-up
+commits in the same release cycle."
+```
+
+---
+
+## Phase 2 — Cover `readonly struct` shape (15 min, 2 tasks)
+
+### Task 2.1: Add `readonly struct` happy + sad path tests
+
+**Files:**
+- Modify: `tests/ZeroAlloc.Validation.Tests/Integration/StructValidationTests.cs`
+
+**Step 1: Append two `[Fact]`s + the matching model**
+
+After the existing `ReadonlyRecordStruct_*` tests, add:
+
+```csharp
+    [Fact]
+    public void ReadonlyStruct_Validate_HappyPath_ReportsValid()
+    {
+        var validator = new RsCommandValidator();
+        var result = validator.Validate(new RsCommand(10));
+        Assert.True(result.IsValid);
+    }
+
+    [Fact]
+    public void ReadonlyStruct_Validate_SadPath_ReportsFailureOnTotal()
+    {
+        var validator = new RsCommandValidator();
+        var result = validator.Validate(new RsCommand(0));
+        Assert.False(result.IsValid);
+        Assert.Equal(nameof(RsCommand.Total), result.Failures[0].PropertyName);
+    }
+}
+
+[Validate]
+public readonly struct RsCommand
+{
+    [GreaterThan(0)]
+    public int Total { get; }
+
+    public RsCommand(int total) => Total = total;
+}
+```
+
+(Move the closing `}` of the class above the new `[Validate]` declaration.)
+
+### Task 2.2: Run + commit
+
+```bash
+dotnet test -c Release --filter "FullyQualifiedName~StructValidationTests"
+```
+
+Expected: 4/4 pass.
+
+```bash
+git add tests/ZeroAlloc.Validation.Tests/Integration/StructValidationTests.cs
+git commit -m "test(generator): readonly struct happy/sad-path coverage"
+```
+
+---
+
+## Phase 3 — `ZV0014` diagnostic for non-readonly structs (30 min, 5 tasks)
+
+### Task 3.1: Write the failing diagnostic test
+
+**Files:**
+- Create: `tests/ZeroAlloc.Validation.Tests/Generator/StructValidationDiagnosticTests.cs`
+
+**Step 1: Write the test file**
+
+```csharp
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+using ZeroAlloc.Validation;
+using ZeroAlloc.Validation.Generator;
+
+namespace ZeroAlloc.Validation.Tests.Generator;
+
+public class StructValidationDiagnosticTests
+{
+    [Fact]
+    public void NonReadonly_RecordStruct_With_Validate_Fires_ZV0014()
+    {
+        var source = """
+            using ZeroAlloc.Validation;
+            namespace TestModels;
+
+            [Validate]
+            public record struct MutableRs([property: GreaterThan(0)] int Total);
+            """;
+
+        var result = RunGenerator(source);
+
+        Assert.Contains(result.Diagnostics, d => d.Id == "ZV0014");
+    }
+
+    [Fact]
+    public void NonReadonly_Struct_With_Validate_Fires_ZV0014()
+    {
+        var source = """
+            using ZeroAlloc.Validation;
+            namespace TestModels;
+
+            [Validate]
+            public struct MutableS
+            {
+                [GreaterThan(0)]
+                public int Total { get; set; }
+            }
+            """;
+
+        var result = RunGenerator(source);
+
+        Assert.Contains(result.Diagnostics, d => d.Id == "ZV0014");
+    }
+
+    [Fact]
+    public void Readonly_RecordStruct_With_Validate_Does_Not_Fire_ZV0014()
+    {
+        var source = """
+            using ZeroAlloc.Validation;
+            namespace TestModels;
+
+            [Validate]
+            public readonly record struct CleanRrs([property: GreaterThan(0)] int Total);
+            """;
+
+        var result = RunGenerator(source);
+
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "ZV0014");
+    }
+
+    [Fact]
+    public void Readonly_Struct_With_Validate_Does_Not_Fire_ZV0014()
+    {
+        var source = """
+            using ZeroAlloc.Validation;
+            namespace TestModels;
+
+            [Validate]
+            public readonly struct CleanRs
+            {
+                [GreaterThan(0)]
+                public int Total { get; }
+                public CleanRs(int total) => Total = total;
+            }
+            """;
+
+        var result = RunGenerator(source);
+
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "ZV0014");
+    }
+
+    [Fact]
+    public void Class_With_Validate_Does_Not_Fire_ZV0014()
+    {
+        var source = """
+            using ZeroAlloc.Validation;
+            namespace TestModels;
+
+            [Validate]
+            public class CleanClass
+            {
+                [GreaterThan(0)]
+                public int Total { get; set; }
+            }
+            """;
+
+        var result = RunGenerator(source);
+
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "ZV0014");
+    }
+
+    private static GeneratorDriverRunResult RunGenerator(string source)
+    {
+        var compilation = CSharpCompilation.Create(
+            "TestAssembly",
+            [CSharpSyntaxTree.ParseText(source)],
+            [
+                MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+                MetadataReference.CreateFromFile(typeof(ValidateAttribute).Assembly.Location),
+            ],
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        var generator = new ValidatorGenerator();
+        var driver = CSharpGeneratorDriver.Create(generator).RunGenerators(compilation);
+        return driver.GetRunResult();
+    }
+}
+```
+
+**Step 2: Run — expect 2 FAIL (the ZV0014-expecting tests) + 3 PASS (the regression nets)**
+
+```bash
+dotnet test -c Release --filter "FullyQualifiedName~StructValidationDiagnosticTests"
+```
+
+Expected: `Failed: 2, Passed: 3`. The two `Fires_ZV0014` tests fail because the diagnostic isn't emitted yet; the three "Does_Not_Fire" tests pass trivially (no diagnostics are emitted from any shape yet).
+
+**No commit yet** — diagnostic implementation is the next step.
+
+### Task 3.2: Declare the `ZV0014` `DiagnosticDescriptor`
+
+**Files:**
+- Modify: `src/ZeroAlloc.Validation.Generator/ValidatorGenerator.cs` (after the `ZV0013` declaration, before `ZV0015`)
+
+**Step 1: Add the descriptor**
+
+Insert between `ZV0013` (lines 42-48) and `ZV0015` (lines 50-56):
+
+```csharp
+    private static readonly DiagnosticDescriptor ZV0014 = new DiagnosticDescriptor(
+        id: "ZV0014",
+        title: "[Validate] on non-readonly struct",
+        messageFormat:
+            "Struct '{0}' is decorated with [Validate] but is not declared `readonly`. " +
+            "A caller can mutate the instance between the validator returning success " +
+            "and the consumer reading the value, making validation results stale. " +
+            "Declare the struct as `readonly struct` or `readonly record struct`.",
+        category: "ZeroAlloc.Validation",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+```
+
+### Task 3.3: Report `ZV0014` inside `Emit`
+
+**Files:**
+- Modify: `src/ZeroAlloc.Validation.Generator/ValidatorGenerator.cs` — the `Emit(SourceProductionContext ctx, INamedTypeSymbol classSymbol, BehaviorCache allBehaviors)` method around line 81.
+
+**Step 1: Add the diagnostic report at the top of `Emit`**
+
+Find the first line of the `Emit` method body and insert the check before any emission work:
+
+```csharp
+    private static void Emit(SourceProductionContext ctx, INamedTypeSymbol classSymbol, BehaviorCache allBehaviors)
+    {
+        // ZV0014 — surface mutability hazard on non-readonly structs. Generator
+        // still proceeds to emit the validator; the warning is informational.
+        if (classSymbol.TypeKind == TypeKind.Struct && !classSymbol.IsReadOnly)
+        {
+            ctx.ReportDiagnostic(Diagnostic.Create(
+                ZV0014,
+                classSymbol.Locations.FirstOrDefault() ?? Location.None,
+                classSymbol.Name));
+        }
+
+        // …existing Emit body continues here unchanged…
+```
+
+`System.Linq` is already imported (line 2 of the file) so `Locations.FirstOrDefault()` resolves.
+
+### Task 3.4: Re-run the diagnostic tests — expect 5/5 PASS
+
+```bash
+dotnet test -c Release --filter "FullyQualifiedName~StructValidationDiagnosticTests"
+```
+
+Expected: all 5 pass — both `Fires_ZV0014` tests now find the diagnostic, the three regression nets stay clean.
+
+### Task 3.5: Update `AnalyzerReleases.Unshipped.md`
+
+**Files:**
+- Modify: `src/ZeroAlloc.Validation.Generator/AnalyzerReleases.Unshipped.md`
+
+**Step 1: Append the new-rule row**
+
+```markdown
+### New Rules
+
+Rule ID | Category             | Severity | Notes
+--------|----------------------|----------|------------------------------
+ZV0014  | ZeroAlloc.Validation | Warning  | [Validate] on non-readonly struct
+```
+
+If the file already has a `### New Rules` header (it's normal during a release cycle), append the `ZV0014` line under it instead of creating a duplicate header.
+
+### Task 3.6: Run the full suite + commit
+
+```bash
+dotnet test -c Release
+```
+
+Expected: every test passes — 9 new + every existing.
+
+```bash
+git add src/ZeroAlloc.Validation.Generator/ValidatorGenerator.cs \
+        src/ZeroAlloc.Validation.Generator/AnalyzerReleases.Unshipped.md \
+        tests/ZeroAlloc.Validation.Tests/Generator/StructValidationDiagnosticTests.cs
+git commit -m "feat(generator): ZV0014 warning on non-readonly struct with [Validate]
+
+Non-readonly structs allow callers to mutate the instance between the
+validator returning success and the consumer reading the value, leaving
+the validation result stale. ZV0014 is a Warning (build-visible, not
+fatal); pragma-disable on a case-by-case basis when the consumer
+cooperates with the hazard. Generator still emits the validator —
+the warning is informational, not a refusal."
+```
+
+---
+
+## Phase 4 — Docs (15 min, 2 tasks)
+
+### Task 4.1: Update `docs/getting-started.md`
+
+**Files:**
+- Modify: `docs/getting-started.md`
+
+**Step 1:** Find the section where `[Validate]` is first introduced (typically titled "Decorate your request type" or similar — search for the literal `[Validate]` in the doc).
+
+**Step 2:** Add this callout immediately after the first `[Validate]` mention:
+
+```markdown
+> **Target types.** `[Validate]` works on `class`, `record`, `readonly struct`, and
+> `readonly record struct`. Decorating a non-readonly `struct` or `record struct`
+> emits `ZV0014` (Warning) — a caller can mutate the instance between the
+> validator returning success and the consumer reading the value, making the
+> validation result stale. Prefer the `readonly` form for request types.
+```
+
+### Task 4.2: Add `ZV0014` to `docs/error-messages.md` + commit
+
+**Files:**
+- Modify: `docs/error-messages.md`
+
+**Step 1:** Find the existing `## ZV0013` / `## ZV0015` headers (or whatever format `error-messages.md` uses for per-diagnostic entries). Insert between them:
+
+```markdown
+## ZV0014 — `[Validate]` on non-readonly struct
+
+**Severity:** Warning
+
+**What it means.** You decorated a `struct` or `record struct` with `[Validate]`,
+but the type is not declared `readonly`. A caller can mutate the instance
+between the validator returning `IsValid == true` and the consumer reading
+the value — making the validation result stale.
+
+**Fix.** Declare the type as `readonly struct` or `readonly record struct`:
+
+```csharp
+[Validate]
+public readonly record struct PlaceOrderCommand(
+    [property: GreaterThan(0)] int CustomerId,
+    [property: GreaterThan(0)] decimal Total);
+```
+
+**Suppressing.** If your call site cooperates with the hazard (e.g. you validate
+inside the same method that constructs the struct and never mutate after),
+suppress with `#pragma warning disable ZV0014` around the type declaration,
+or add `<NoWarn>$(NoWarn);ZV0014</NoWarn>` in the consuming project.
+```
+
+**Step 2:** Commit.
+
+```bash
+git add docs/getting-started.md docs/error-messages.md
+git commit -m "docs: ZV0014 + struct target callout in getting-started"
+```
+
+---
+
+## Phase 5 — Verify + ship (15 min, 4 tasks)
+
+### Task 5.1: Run the full repo test suite one final time
+
+```bash
+cd c:/Projects/Prive/ZeroAlloc/ZeroAlloc.Validation
+dotnet test -c Release
+```
+
+Expected: every test passes — the 4 new integration tests, the 5 new diagnostic tests, and every existing test from before this branch.
+
+If anything is red, fix on-branch before pushing.
+
+### Task 5.2: Push the branch + open the PR
+
+```bash
+git push -u origin feat/validate-struct-target
+gh pr create \
+  --title "feat(generator): [Validate] now accepts struct and record struct" \
+  --body "$(cat <<'EOF'
+## Summary
+
+Closes backlog B2. Widens `[Validate]` from `Class` to `Class | Struct` so the four C# shapes — `class`, `record`, `struct`, `record struct` — all participate. Non-readonly structs raise `ZV0014` (Warning).
+
+Surfaced 2026-05-26 building the `za-vertical-slice` template ([ZeroAlloc.Templates#117](https://github.com/ZeroAlloc-Net/ZeroAlloc.Templates/pull/117)) — request types had to widen from `readonly record struct` to `sealed record` solely to attach `[Validate]`.
+
+## What changed
+
+- `ValidateAttribute` — target widened to `Class | Struct`.
+- Generator syntax predicate — accepts `StructDeclarationSyntax` and `RecordStructDeclarationSyntax`.
+- New `ZV0014` Warning when `[Validate]` decorates a non-readonly struct.
+- 4 integration tests covering `readonly struct` and `readonly record struct` happy/sad paths.
+- 5 generator diagnostic tests covering the matrix of shape × readonly-ness (class is the regression net).
+- `docs/getting-started.md` callout + `docs/error-messages.md` ZV0014 entry.
+
+## Decisions ([design doc](docs/plans/2026-05-27-validate-struct-target-design.md))
+
+- **No `Validate(in T)` overload on `ValidatorFor<T>`.** Pass-by-value matches the existing base. For typical request structs (≤32 bytes) the stack copy is below noise on the measured allocation profile (Validator_Generated at 2.18 ns / 0 B). Deferred until a consumer measures the copy cost as load-bearing.
+- **`ZV0014` is a Warning, not Error.** Hard refusal would be paternalistic for a v1.x minor — legitimate mutable-then-frozen patterns exist. Opt-out via single-line pragma is trivial.
+- **No restriction to `readonly`.** Generator accepts all four shapes; the diagnostic raises the loud signal at compile time without blocking the build.
+
+## SemVer
+
+`1.2.0` → `1.3.0` (additive minor — existing class/record consumers see zero behaviour change).
+
+## Test plan
+
+- [x] `dotnet test -c Release` — all green locally
+- [ ] CI — green on this PR
+- [ ] After 1.3.0 propagates: ZeroAlloc.Templates follow-up PR migrates `za-vertical-slice`'s 4 request types from `sealed record` back to `readonly record struct`
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+### Task 5.3: Watch CI
+
+```bash
+gh pr checks --watch
+```
+
+If anything fails, diagnose on-branch and push fixes. The likely failure modes are: snapshot drift in some other generator test that wasn't aware of the new predicate types, or `AnalyzerReleases.Unshipped.md` formatting tripping the release-tracking analyzer.
+
+### Task 5.4: Admin-merge + release
+
+After CI lands green:
+
+```bash
+gh pr merge --admin --squash --delete-branch
+```
+
+Release-please opens a release PR (`chore(main): release 1.3.0`). Admin-merge that too. NuGet propagation typically takes 2-5 minutes.
+
+Verify:
+
+```bash
+curl -s "https://api.nuget.org/v3-flatcontainer/zeroalloc.validation/index.json" | python -c "import sys, json; v = json.load(sys.stdin)['versions']; print('latest:', v[-1])"
+```
+
+Expected: `latest: 1.3.0`.
+
+### Task 5.5: Workspace + repo backlog hygiene
+
+**Repo backlog** — edit `docs/backlog.md` to strike B2 and add the shipped marker:
+
+```markdown
+## ~~B2 — `[Validate]` on `record`, `record struct`, and `struct` targets~~ — ✅ shipped 1.3.0 (2026-05-27)
+
+**Shipped:** as designed — `AttributeTargets.Class | AttributeTargets.Struct`,
+generator predicate widened, ZV0014 Warning on non-readonly structs.
+See `docs/plans/2026-05-27-validate-struct-target-design.md` + PR #XX.
+```
+
+(Strikethrough the heading and prepend the shipped block above the original body, matching how B1 will eventually be marked.)
+
+Commit:
+
+```bash
+git checkout main && git pull
+git add docs/backlog.md
+git commit -m "docs(backlog): mark B2 shipped (1.3.0)"
+git push
+```
+
+**Workspace BACKLOG.md** — `c:/Projects/Prive/ZeroAlloc/docs/BACKLOG.md`. Not git-tracked; this is a workspace edit only. Not strictly required, but if you maintain it, add a one-line entry under the ZeroAlloc.Validation section noting 1.3.0 shipped with B2.
+
+---
+
+## Verification checklist
+
+- [ ] **Phase 1:** `[Validate]` decorates a `readonly record struct`; generator emits the validator class; 2 happy/sad tests pass.
+- [ ] **Phase 2:** `readonly struct` works identically; 2 more tests pass.
+- [ ] **Phase 3:** `ZV0014` fires on non-readonly `struct` + `record struct`; doesn't fire on `readonly` forms or on `class`; 5 diagnostic tests pass.
+- [ ] **Phase 4:** `docs/getting-started.md` callout + `docs/error-messages.md` ZV0014 section landed.
+- [ ] **Phase 5:** CI green, admin-merged, release-please cuts 1.3.0, NuGet propagates, B2 marked shipped in both backlogs.
+
+## Out of scope (deferred, separate brainstorm)
+
+- **B1 — value-object-aware property validators** (`[GreaterThan(0)] CustomerId Id` unwraps to `.Value`). Independent of this PR; ships as a separate 1.x minor after B2.
+- **`Validate(in T)` overload on `ValidatorFor<T>`** for zero-copy struct validation. Deferred until benchmarks show the copy cost matters.
+- **Template migration** — `za-vertical-slice` request types stay on `sealed record` until 1.3.0 propagates to NuGet, then a follow-up PR over there migrates them to `readonly record struct`.

--- a/src/ZeroAlloc.Validation.Generator/AnalyzerReleases.Unshipped.md
+++ b/src/ZeroAlloc.Validation.Generator/AnalyzerReleases.Unshipped.md
@@ -8,4 +8,5 @@ Rule ID | Category | Severity | Notes
 ZV0011 | ZeroAlloc.Validation | Warning | Redundant [ValidateWith] attribute
 ZV0012 | ZeroAlloc.Validation | Error | Invalid [ValidateWith] validator type
 ZV0013 | ZeroAlloc.Validation | Error | Invalid [CustomValidation] method signature
+ZV0014 | ZeroAlloc.Validation | Warning | [Validate] on non-readonly struct
 ZV0015 | ZeroAlloc.Validation | Error | Duplicate pipeline behavior Order

--- a/src/ZeroAlloc.Validation.Generator/ValidatorGenerator.cs
+++ b/src/ZeroAlloc.Validation.Generator/ValidatorGenerator.cs
@@ -47,6 +47,18 @@ public sealed class ValidatorGenerator : IIncrementalGenerator
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true);
 
+    private static readonly DiagnosticDescriptor ZV0014 = new DiagnosticDescriptor(
+        id: "ZV0014",
+        title: "[Validate] on non-readonly struct",
+        messageFormat:
+            "Struct '{0}' is decorated with [Validate] but is not declared `readonly`. " +
+            "A caller can mutate the instance between the validator returning success " +
+            "and the consumer reading the value, making validation results stale. " +
+            "Declare the struct as `readonly struct` or `readonly record struct`.",
+        category: "ZeroAlloc.Validation",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
     private static readonly DiagnosticDescriptor ZV0015 = new DiagnosticDescriptor(
         id: "ZV0015",
         title: "Duplicate pipeline behavior Order",
@@ -85,6 +97,16 @@ public sealed class ValidatorGenerator : IIncrementalGenerator
 
     private static void Emit(SourceProductionContext ctx, INamedTypeSymbol classSymbol, BehaviorCache allBehaviors)
     {
+        // ZV0014 — surface mutability hazard on non-readonly structs. Generator
+        // still proceeds to emit the validator; the warning is informational.
+        if (classSymbol.TypeKind == TypeKind.Struct && !classSymbol.IsReadOnly)
+        {
+            ctx.ReportDiagnostic(Diagnostic.Create(
+                ZV0014,
+                classSymbol.Locations.FirstOrDefault() ?? Location.None,
+                classSymbol.Name));
+        }
+
         var modelFqn = classSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
         var (syncBehaviors, asyncBehaviors) = BehaviorDiscoverer.ForModel(allBehaviors.Sync, allBehaviors.Async, modelFqn);
 

--- a/src/ZeroAlloc.Validation.Generator/ValidatorGenerator.cs
+++ b/src/ZeroAlloc.Validation.Generator/ValidatorGenerator.cs
@@ -60,10 +60,15 @@ public sealed class ValidatorGenerator : IIncrementalGenerator
         var validateClasses = context.SyntaxProvider
             .ForAttributeWithMetadataName(
                 ValidateAttributeFqn,
-                // Accept both classes and records (positional records are
-                // RecordDeclarationSyntax, not ClassDeclarationSyntax — the
-                // generator walks symbol properties identically for both).
-                predicate: static (node, _) => node is ClassDeclarationSyntax or RecordDeclarationSyntax,
+                // All four C# shapes — class, record (class), struct, record struct — hit
+                // the same emission path; the downstream generator walks symbol properties
+                // identically regardless of TypeKind. Note: Roslyn represents both
+                // `record` and `record struct` with RecordDeclarationSyntax (kind
+                // differs at the token level), so only three syntax types are needed.
+                predicate: static (node, _) =>
+                    node is ClassDeclarationSyntax
+                         or RecordDeclarationSyntax
+                         or StructDeclarationSyntax,
                 transform: static (ctx, _) => (INamedTypeSymbol)ctx.TargetSymbol);
 
 #pragma warning disable EPS06 // IncrementalValuesProvider<T> is a struct; Combine is the standard Roslyn API

--- a/src/ZeroAlloc.Validation/Attributes/ValidateAttribute.cs
+++ b/src/ZeroAlloc.Validation/Attributes/ValidateAttribute.cs
@@ -1,6 +1,6 @@
 namespace ZeroAlloc.Validation;
 
-[AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct, AllowMultiple = false)]
 public sealed class ValidateAttribute : Attribute
 {
     public bool StopOnFirstFailure { get; set; }

--- a/tests/ZeroAlloc.Validation.Tests/Generator/StructValidationDiagnosticTests.cs
+++ b/tests/ZeroAlloc.Validation.Tests/Generator/StructValidationDiagnosticTests.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+using ZeroAlloc.Validation;
+using ZeroAlloc.Validation.Generator;
+
+namespace ZeroAlloc.Validation.Tests.Generator;
+
+public class StructValidationDiagnosticTests
+{
+    [Fact]
+    public void NonReadonly_RecordStruct_With_Validate_Fires_ZV0014()
+    {
+        var source = """
+            using ZeroAlloc.Validation;
+            namespace TestModels;
+
+            [Validate]
+            public record struct MutableRs([property: GreaterThan(0)] int Total);
+            """;
+
+        var result = RunGenerator(source);
+
+        Assert.Contains(result.Diagnostics, d => string.Equals(d.Id, "ZV0014", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void NonReadonly_Struct_With_Validate_Fires_ZV0014()
+    {
+        var source = """
+            using ZeroAlloc.Validation;
+            namespace TestModels;
+
+            [Validate]
+            public struct MutableS
+            {
+                [GreaterThan(0)]
+                public int Total { get; set; }
+            }
+            """;
+
+        var result = RunGenerator(source);
+
+        Assert.Contains(result.Diagnostics, d => string.Equals(d.Id, "ZV0014", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Readonly_RecordStruct_With_Validate_Does_Not_Fire_ZV0014()
+    {
+        var source = """
+            using ZeroAlloc.Validation;
+            namespace TestModels;
+
+            [Validate]
+            public readonly record struct CleanRrs([property: GreaterThan(0)] int Total);
+            """;
+
+        var result = RunGenerator(source);
+
+        Assert.DoesNotContain(result.Diagnostics, d => string.Equals(d.Id, "ZV0014", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Readonly_Struct_With_Validate_Does_Not_Fire_ZV0014()
+    {
+        var source = """
+            using ZeroAlloc.Validation;
+            namespace TestModels;
+
+            [Validate]
+            public readonly struct CleanRs
+            {
+                [GreaterThan(0)]
+                public int Total { get; }
+                public CleanRs(int total) => Total = total;
+            }
+            """;
+
+        var result = RunGenerator(source);
+
+        Assert.DoesNotContain(result.Diagnostics, d => string.Equals(d.Id, "ZV0014", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Class_With_Validate_Does_Not_Fire_ZV0014()
+    {
+        var source = """
+            using ZeroAlloc.Validation;
+            namespace TestModels;
+
+            [Validate]
+            public class CleanClass
+            {
+                [GreaterThan(0)]
+                public int Total { get; set; }
+            }
+            """;
+
+        var result = RunGenerator(source);
+
+        Assert.DoesNotContain(result.Diagnostics, d => string.Equals(d.Id, "ZV0014", StringComparison.Ordinal));
+    }
+
+    private static GeneratorDriverRunResult RunGenerator(string source)
+    {
+        var compilation = CSharpCompilation.Create(
+            "TestAssembly",
+            [CSharpSyntaxTree.ParseText(source)],
+            [
+                MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+                MetadataReference.CreateFromFile(typeof(ValidateAttribute).Assembly.Location),
+            ],
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        var generator = new ValidatorGenerator();
+        var driver = CSharpGeneratorDriver.Create(generator).RunGenerators(compilation);
+        return driver.GetRunResult();
+    }
+}

--- a/tests/ZeroAlloc.Validation.Tests/Integration/StructValidationTests.cs
+++ b/tests/ZeroAlloc.Validation.Tests/Integration/StructValidationTests.cs
@@ -1,0 +1,29 @@
+using Xunit;
+using ZeroAlloc.Validation;
+
+#pragma warning disable MA0048 // multiple types intentionally co-located with the test class
+
+namespace ZeroAlloc.Validation.Tests.Integration;
+
+public class StructValidationTests
+{
+    [Fact]
+    public void ReadonlyRecordStruct_Validate_HappyPath_ReportsValid()
+    {
+        var validator = new RrsCommandValidator();
+        var result = validator.Validate(new RrsCommand(Total: 10));
+        Assert.True(result.IsValid);
+    }
+
+    [Fact]
+    public void ReadonlyRecordStruct_Validate_SadPath_ReportsFailureOnTotal()
+    {
+        var validator = new RrsCommandValidator();
+        var result = validator.Validate(new RrsCommand(Total: 0));
+        Assert.False(result.IsValid);
+        Assert.Equal(nameof(RrsCommand.Total), result.Failures[0].PropertyName);
+    }
+}
+
+[Validate]
+public readonly record struct RrsCommand([property: GreaterThan(0)] int Total);

--- a/tests/ZeroAlloc.Validation.Tests/Integration/StructValidationTests.cs
+++ b/tests/ZeroAlloc.Validation.Tests/Integration/StructValidationTests.cs
@@ -25,7 +25,35 @@ public class StructValidationTests
         Assert.Equal(1, result.Failures.Length);
         Assert.Equal(nameof(RrsCommand.Total), result.Failures[0].PropertyName);
     }
+
+    [Fact]
+    public void ReadonlyStruct_Validate_HappyPath_ReportsValid()
+    {
+        var validator = new RsCommandValidator();
+        var result = validator.Validate(new RsCommand(10));
+        Assert.True(result.IsValid);
+        Assert.True(result.Failures.IsEmpty);
+    }
+
+    [Fact]
+    public void ReadonlyStruct_Validate_SadPath_ReportsFailureOnTotal()
+    {
+        var validator = new RsCommandValidator();
+        var result = validator.Validate(new RsCommand(0));
+        Assert.False(result.IsValid);
+        Assert.Equal(1, result.Failures.Length);
+        Assert.Equal(nameof(RsCommand.Total), result.Failures[0].PropertyName);
+    }
 }
 
 [Validate]
 public readonly record struct RrsCommand([property: GreaterThan(0)] int Total);
+
+[Validate]
+public readonly struct RsCommand
+{
+    [GreaterThan(0)]
+    public int Total { get; }
+
+    public RsCommand(int total) => Total = total;
+}

--- a/tests/ZeroAlloc.Validation.Tests/Integration/StructValidationTests.cs
+++ b/tests/ZeroAlloc.Validation.Tests/Integration/StructValidationTests.cs
@@ -13,6 +13,7 @@ public class StructValidationTests
         var validator = new RrsCommandValidator();
         var result = validator.Validate(new RrsCommand(Total: 10));
         Assert.True(result.IsValid);
+        Assert.True(result.Failures.IsEmpty);
     }
 
     [Fact]
@@ -21,6 +22,7 @@ public class StructValidationTests
         var validator = new RrsCommandValidator();
         var result = validator.Validate(new RrsCommand(Total: 0));
         Assert.False(result.IsValid);
+        Assert.Equal(1, result.Failures.Length);
         Assert.Equal(nameof(RrsCommand.Total), result.Failures[0].PropertyName);
     }
 }


### PR DESCRIPTION
## Summary

Closes backlog item B2. Widens `[Validate]` from `AttributeTargets.Class` to `AttributeTargets.Class | AttributeTargets.Struct` so the four C# declaration shapes — `class`, `record`, `struct`, `record struct` — all participate. Non-readonly structs raise `ZV0014` (Warning) flagging the mutation-staleness hazard.

Surfaced 2026-05-26 building the `za-vertical-slice` template ([ZeroAlloc.Templates#117](https://github.com/ZeroAlloc-Net/ZeroAlloc.Templates/pull/117), shipped 2026-05-27 as Templates 0.7.0). The template's four request types had to widen from `readonly record struct` to `sealed record` solely to attach `[Validate]`. This PR unblocks the original shape.

## What changed

- **`ValidateAttribute`** — target widened to `Class | Struct`.
- **Generator syntax predicate** — accepts `StructDeclarationSyntax` in addition to the existing `ClassDeclarationSyntax` and `RecordDeclarationSyntax`. (Note: `record struct` is already represented by `RecordDeclarationSyntax` in Roslyn — there's no separate `RecordStructDeclarationSyntax` type.)
- **New `ZV0014` Warning** — fires when `[Validate]` decorates a non-readonly struct or non-readonly record struct. Generator still emits the validator; the warning is informational.
- **4 integration tests** covering `readonly struct` and `readonly record struct` happy/sad paths (`StructValidationTests`).
- **5 generator diagnostic tests** covering the matrix of shape × readonly-ness (`StructValidationDiagnosticTests`).
- **`AnalyzerReleases.Unshipped.md`** — `ZV0014` row in `### New Rules`.
- **`docs/getting-started.md`** — callout listing the four supported shapes + the ZV0014 hazard.
- **`docs/diagnostics.md`** — `## ZV0014` section between `ZV0013` and `ZV0015`, plus a summary-table row.

## Decisions ([design doc](docs/plans/2026-05-27-validate-struct-target-design.md))

- **No `Validate(in T)` overload on `ValidatorFor<T>`.** Pass-by-value matches the existing base. For typical request structs (≤32 bytes) the stack copy is below noise on the measured allocation profile (Validator_Generated at 2.18 ns / 0 B in the za-vertical-slice benchmarks). Deferred until a consumer measures the copy cost as load-bearing.
- **`ZV0014` is a Warning, not Error.** Hard refusal would be paternalistic for a v1.x minor — legitimate mutable-then-frozen patterns exist. Opt-out via `#pragma warning disable ZV0014` is trivial.
- **No restriction to `readonly`.** Generator accepts all four shapes; the diagnostic raises the loud signal at compile time without blocking the build.

## SemVer

`1.2.0` → `1.3.0` (additive minor — existing class/record consumers see zero behaviour change).

## Test plan

- [x] `dotnet test -c Release` — all green locally on net8 / net9 / net10 (293 main + 5 AspNetCore + 6 Options + 4 Inject + 2 MSTest + 2 NUnit, every TFM)
- [ ] CI — green on this PR
- [ ] Follow-up after 1.3.0 propagates to NuGet: ZeroAlloc.Templates migrates `za-vertical-slice`'s 4 request types from `sealed record` back to `readonly record struct`

🤖 Generated with [Claude Code](https://claude.com/claude-code)