### PR TITLE
feat(generator): unwrap [ValueObject] properties in built-in validators

### DIFF
--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -2,7 +2,7 @@
 id: diagnostics
 title: Compiler Diagnostics
 slug: /docs/diagnostics
-description: ZV0011–ZV0015 Roslyn analyzer rules emitted by ZeroAlloc.Validation.Generator, with triggers, severities, and fix guidance.
+description: ZV0011–ZV0016 Roslyn analyzer rules emitted by ZeroAlloc.Validation.Generator, with triggers, severities, and fix guidance.
 sidebar_position: 11
 ---
 
@@ -17,6 +17,7 @@ ZeroAlloc.Validation.Generator emits the following Roslyn diagnostics at compile
 | [ZV0013](#zv0013) | Error | Invalid [CustomValidation] method signature |
 | [ZV0014](#zv0014) | Warning | [Validate] on non-readonly struct |
 | [ZV0015](#zv0015) | Error | Duplicate pipeline behavior Order |
+| [ZV0016](#zv0016) | Warning | Multi-property value-object can't be auto-unwrapped |
 
 ---
 
@@ -108,3 +109,37 @@ public class LoggingBehavior : IPipelineBehavior { /* ... */ }
 [PipelineBehavior(Order = 1)]   // was also 0 — now unique
 public class AuditBehavior : IPipelineBehavior { /* ... */ }
 ```
+
+---
+
+## ZV0016
+
+**Severity:** Warning
+
+**Title:** Multi-property value-object can't be auto-unwrapped
+
+**When fired:** A property carries a built-in operand validator (e.g. `[GreaterThan]`, `[NotEmpty]`) and its type is decorated with `[ZeroAlloc.ValueObjects.ValueObject]` but exposes more than one public instance property. Auto-unwrap only works for single-property wrappers — there is no single underlying value to compare against.
+
+**Fix:** Either expose the validation through a single-property wrapper, or replace the built-in operand validator with `[Must]` / `[CustomValidation]` carrying a custom predicate that knows how to inspect the multi-property type:
+
+```csharp
+[ValueObject]
+public readonly partial struct Money
+{
+    public decimal Amount { get; }
+    public string Currency { get; }
+    public Money(decimal amount, string currency) { Amount = amount; Currency = currency; }
+}
+
+[Validate]
+public partial class PriceCommand
+{
+    // [GreaterThan(0)] Money Total      // would emit ZV0016 — Money has two properties
+    [Must(nameof(IsPositive))]
+    public Money Total { get; set; }
+
+    public bool IsPositive(Money m) => m.Amount > 0;
+}
+```
+
+**Suppressing:** If your intent is to constrain a different property (e.g. only the `.Amount` component), refactor the model so the constrained surface is a single-property value-object. To silence the warning without restructuring, add `#pragma warning disable ZV0016` around the property declaration or `<NoWarn>$(NoWarn);ZV0016</NoWarn>` in the consuming project — but note that the underlying validator emission will still be incorrect for the multi-property case; a custom predicate is the recommended fix.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -93,6 +93,44 @@ Each `ValidationFailure` carries:
 - `ErrorCode` — an optional machine-readable code
 - `Severity` — `Error`, `Warning`, or `Info`
 
+## Validating value-object properties
+
+If a property's type is decorated with `[ZeroAlloc.ValueObjects.ValueObject]` and exposes exactly one public instance property (a typed-id wrapper, for example), the built-in operand-style validators auto-unwrap through the wrapper. You annotate the wrapper; the generator emits the comparison against the underlying value.
+
+```csharp
+using ZeroAlloc.Validation;
+using ZeroAlloc.ValueObjects;
+
+[ValueObject]
+public readonly partial struct CustomerId
+{
+    public int Value { get; }
+    public CustomerId(int value) => Value = value;
+}
+
+[Validate]
+public readonly record struct PlaceOrderCommand(
+    [property: GreaterThan(0)] CustomerId CustomerId,
+    [property: GreaterThan(0)] decimal Total);
+```
+
+The generator emits `instance.CustomerId.Value > 0` rather than trying to compare the wrapper itself — so `[GreaterThan]`, `[NotEmpty]`, `[InclusiveBetween]`, and the other operand-taking attributes "just work" against typed ids and other single-property value-objects.
+
+**Predicate validators preserve the wrapper.** `[Must(nameof(IsKnown))]` passes the wrapper into your method, not the unwrap — the method signature is what the user wrote:
+
+```csharp
+[Validate]
+public partial class PlaceOrderCommand
+{
+    [Must(nameof(IsKnown))]
+    public CustomerId CustomerId { get; set; }
+
+    public bool IsKnown(CustomerId id) => id.Value > 0;
+}
+```
+
+**Multi-property value-objects.** Auto-unwrap only applies when the wrapper has a single underlying property. If you put a built-in operand validator on a multi-property value-object (e.g. a `Money { decimal Amount; string Currency; }`), the generator emits `ZV0016` (Warning) — there is no single property to unwrap through. Use `[Must]` with a custom predicate instead.
+
 ## Next steps
 
 - [Attribute Reference](attributes.md) — all 25+ built-in attributes

--- a/docs/plans/2026-05-27-value-object-property-validators-design.md
+++ b/docs/plans/2026-05-27-value-object-property-validators-design.md
@@ -1,0 +1,209 @@
+# Value-Object-Aware Property Validators — Design
+
+**Date:** 2026-05-27
+**Scope:** ZeroAlloc.Validation generator recognises properties whose declared type is a single-property `[ZeroAlloc.ValueObjects.ValueObject]` partial struct and rewrites the validator's property-access expression to unwrap through the single underlying member. Built-in operand-taking validators (`[GreaterThan]`, `[LessThan]`, `[InclusiveBetween]`, `[NotEmpty]`, `[Matches]`, `[EmailAddress]`, `[Length]`, etc.) now accept value-object-typed properties directly; predicate validators (`[Must]`, `[CustomValidation]`, `[ValidateWith]`) keep passing the wrapper unchanged. Closes backlog item B1. Ships as **ZeroAlloc.Validation 1.5.0** (additive minor — new shapes compile that previously didn't; existing class/primitive consumers see no behaviour change).
+
+## Background
+
+`za-vertical-slice`'s six `[Validate]` request types ship today as `readonly record struct X([property: GreaterThan(0)] int CustomerId, ...)` — they had to fall back to **raw primitive** properties because `[GreaterThan(0)]` couldn't see through `CustomerId` (a `[ValueObject]` partial struct wrapping `int`). The handler then wraps to `new CustomerId(request.CustomerId)` on the way through. This weakens the request-side type signal exactly where validation should reinforce it: `int CustomerId` in a `PlaceOrderCommand` reads as "any int", not "a customer's id."
+
+Friction surfaced 2026-05-26 building the `za-vertical-slice` template (ZeroAlloc.Templates 0.4.0 → 0.7.x). Same pattern hits every consumer that combines `[Validate]` with `[ValueObject]`-typed identifiers.
+
+The validators today emit code like:
+
+```csharp
+if (instance.CustomerId <= 0)
+    _buf.Add(new ValidationFailure { ... });
+```
+
+When `CustomerId` is `int`, this compiles. When `CustomerId` is a value-object wrapper, `<=` operator isn't defined → CS0019. The fix rewrites the access expression to `instance.CustomerId.Value` (or whatever the single underlying property name is) **before** the validator emission consumes it.
+
+`[ZeroAlloc.ValueObjects.ValueObjectAttribute]` (sealed, defined in `src/ZeroAlloc.ValueObjects/ValueObjectAttribute.cs`) is the canonical marker. ZA.ValueObjects' source generator emits the underlying property and constructor; the property name is determined by the user's declaration, typically `Value` for TypedIds but anything is legal.
+
+## Goal
+
+`[Validate]` request types can carry value-object-typed properties alongside primitives, and all built-in operand-taking validators participate naturally. Existing class/primitive properties see no behaviour change. A clear diagnostic (`ZV0016` Warning) fires when a multi-property value-object (e.g. `Money { Amount, Currency }`) carries a built-in validator — the unwrap is ambiguous; user picks either a single-property value-object or a custom-predicate validator.
+
+## Decisions
+
+### D-1: detection — attribute-based on `[ValueObject]`'s FQN
+
+Detect value-object types by matching `INamedTypeSymbol.GetAttributes()` against the FQN `ZeroAlloc.ValueObjects.ValueObjectAttribute`. Same pattern ZA.Validation already uses for its own `[Validate]` marker (`ValidateAttributeFqn` in `RuleEmitter.cs`). No runtime-assembly reference to ZA.ValueObjects — only the attribute's metadata name matters.
+
+**Why not duck-typing** ("single readable property of the validator's operand type"): too loose. Any user-defined `readonly struct Wrap(int n)` that happens to have a single readable int property would silently participate, surprising adopters who didn't intend the rewrite. Attribute-based is explicit: the rewrite kicks in exactly when the type's author opted into value-object semantics.
+
+**Why not interface-based** (`IValueObject<T>`): the cleanest API but ZA.ValueObjects doesn't currently emit such an interface. Introducing it would require a coordinated change to ZA.ValueObjects' generator + a major bump. Out of scope for B1.
+
+**Adopters who don't reference ZA.ValueObjects** pay nothing — `GetAttributes()` doesn't find the FQN, helper returns `null`, generator emits identical output to today.
+
+### D-2: scope — built-in operand-taking validators, predicate validators carved out
+
+The rewrite applies uniformly to **every** built-in validator that consumes a property access as an operand:
+
+- Comparison: `[GreaterThan]`, `[GreaterThanOrEqualTo]`, `[LessThan]`, `[LessThanOrEqualTo]`, `[Equal]`, `[NotEqual]`
+- Range: `[InclusiveBetween]`, `[ExclusiveBetween]`
+- String / collection: `[NotEmpty]`, `[Empty]`, `[Length]`, `[MinLength]`, `[MaxLength]`, `[Matches]`, `[EmailAddress]`
+- Structural: `[PrecisionScale]` (decimal)
+- Enum: `[IsInEnum]`, `[IsEnumName]`
+
+Predicate validators **don't participate** by design:
+
+- `[Must]` — calls a user-provided predicate whose signature picks its own argument type. If the user wrote `bool IsValid(CustomerId c)` they expect the wrapper; if they wrote `bool IsValid(int v)` they wanted the unwrap. The compile-time type-match between the predicate signature and the property's declared type is what dictates this — the generator doesn't override the user's choice.
+- `[CustomValidation]` — same: invokes user code with the property as input.
+- `[ValidateWith]` — points at a nested `ValidatorFor<T>`, where T's identity drives the match.
+
+Falls out naturally from the implementation (D-4): the rewrite happens at the **property-access expression** the rule-emission methods consume. Predicate validators don't take that expression as an operand — they pass the property value via the user-controlled method dispatch — so they're never touched by the rewrite.
+
+### D-3: multi-property value-objects — fall through + `ZV0016` Warning
+
+Single-property value-object → unwrap unambiguous → rewrite. Multi-property value-object (`Money { Amount, Currency }`) → unwrap ambiguous → **no rewrite**. The generator emits the validator against the wrapper as today, which produces the existing CS0019 / type-mismatch compile error.
+
+Layered on top: `ZV0016` Warning when a built-in operand-taking validator is declared on a property whose type carries `[ValueObject]` but has more than one property. Tells the user *why* the rewrite didn't help.
+
+```csharp
+private static readonly DiagnosticDescriptor ZV0016 = new DiagnosticDescriptor(
+    id: "ZV0016",
+    title: "Value-object with multiple properties can't be auto-unwrapped",
+    messageFormat:
+        "Property '{0}' of type '{1}' carries a built-in validator but '{1}' is a multi-property value-object ({2} properties). " +
+        "Auto-unwrap requires exactly one underlying property. " +
+        "Either declare the validator on a single-property value-object, or use [Must] / [CustomValidation] with a custom predicate.",
+    category: "ZeroAlloc.Validation",
+    defaultSeverity: DiagnosticSeverity.Warning,
+    isEnabledByDefault: true);
+```
+
+ID `ZV0016` fills the gap after `ZV0014` (struct target — shipped 1.4.0). `ZV0015` is the existing pipeline-behavior `Order` collision diagnostic.
+
+**Considered and rejected:**
+
+- **Pick a property by convention** (named `Value`, or first declared). Surprises adopters who renamed it; quietly breaks on field reorder. Rejected.
+- **`MemberOf` hint on the validator attribute** (e.g. `[GreaterThan(0, MemberOf = nameof(Money.Amount))]`). API expansion only justified if multi-property value-objects with built-in validators is a load-bearing use case. No current consumer; YAGNI.
+
+### D-4: rewrite at the property-access construction site, not per validator
+
+`RuleEmitter` builds a `propAccess` expression (`$"{modelParamName}.{prop.Name}"`) before iterating the property's rules. Each rule-emission method bakes `propAccess` into the comparison/regex/length code (`$"if ({propAccess} <= 0)"`).
+
+The fix is **one rewrite at the `propAccess` builder**:
+
+```csharp
+var unwrapMember = GetValueObjectUnwrapMember(prop.Type);
+var propAccess = unwrapMember is not null
+    ? $"{modelParamName}.{prop.Name}.{unwrapMember}"
+    : $"{modelParamName}.{prop.Name}";
+```
+
+After this single change, every operand-taking validator emission method works unchanged — they all consume `propAccess` and don't care that it now accesses through a field. Predicate-validator emission methods (which take the property's identity, not its operand-form access) are unaffected.
+
+**Why not per-validator-method opt-in:** would require touching every `Emit{Validator}` method (dozens of files / methods), each potentially with a slightly different shape. Fragile across new validators added in the future. The single-point rewrite scales automatically.
+
+### D-5: helper placement + property-name derivation
+
+```csharp
+// src/ZeroAlloc.Validation.Generator/RuleEmitter.cs
+
+private const string ValueObjectAttributeFqn = "ZeroAlloc.ValueObjects.ValueObjectAttribute";
+
+/// <summary>
+/// If <paramref name="type"/> is a single-property value-object (decorated
+/// with <c>[ZeroAlloc.ValueObjects.ValueObject]</c> and declaring exactly one
+/// public instance property), returns that property's name. Returns null for
+/// everything else — class types, primitives, multi-property value-objects,
+/// or types without the marker attribute.
+/// </summary>
+private static string? GetValueObjectUnwrapMember(ITypeSymbol type)
+{
+    if (type is not INamedTypeSymbol named) return null;
+
+    var hasMarker = named.GetAttributes()
+        .Any(a => string.Equals(
+            a.AttributeClass?.ToDisplayString(),
+            ValueObjectAttributeFqn,
+            StringComparison.Ordinal));
+    if (!hasMarker) return null;
+
+    var properties = named.GetMembers()
+        .OfType<IPropertySymbol>()
+        .Where(p => !p.IsStatic && p.DeclaredAccessibility == Accessibility.Public)
+        .ToArray();
+
+    return properties.Length == 1 ? properties[0].Name : null;
+}
+
+/// <summary>
+/// True when <paramref name="type"/> carries <c>[ValueObject]</c>; used to fire
+/// the multi-property diagnostic ZV0016 even when <see cref="GetValueObjectUnwrapMember"/>
+/// returns null (i.e. multi-property case).
+/// </summary>
+private static bool HasValueObjectAttribute(ITypeSymbol type) =>
+    type is INamedTypeSymbol named
+    && named.GetAttributes().Any(a => string.Equals(
+        a.AttributeClass?.ToDisplayString(),
+        ValueObjectAttributeFqn,
+        StringComparison.Ordinal));
+```
+
+`GetValueObjectUnwrapMember` returns the actual property symbol name (not hardcoded `"Value"`). Works whether the user wrote `int Value`, `string Name`, or any single-prop wrapper shape.
+
+## Design
+
+### Files touched
+
+- **MOD:** `src/ZeroAlloc.Validation.Generator/RuleEmitter.cs` — add helper pair + the rewrite at the `propAccess` builder + `ZV0016` descriptor + diagnostic emission.
+- **MOD:** `src/ZeroAlloc.Validation.Generator/AnalyzerReleases.Unshipped.md` — add `ZV0016` row.
+- **NEW:** `tests/ZeroAlloc.Validation.Tests/Integration/ValueObjectPropertyValidationTests.cs` — runtime behaviour, 4 cases.
+- **NEW:** `tests/ZeroAlloc.Validation.Tests/Generator/ValueObjectPropertyDiagnosticTests.cs` — generator-snapshot, 4 cases.
+- **MOD:** `docs/getting-started.md` — "Validating value-object properties" subsection.
+- **MOD:** `docs/diagnostics.md` — `## ZV0016` entry + summary-table row.
+- **MOD:** `docs/backlog.md` — mark B1 ✅ shipped 1.5.0 on release-PR merge.
+
+### Test surface
+
+**Integration** (`ValueObjectPropertyValidationTests.cs`, 4 cases):
+
+| # | Shape | Assertion |
+|---|---|---|
+| 1 | `[Validate] X([property: GreaterThan(0)] CustomerId Id)` — single-property value-object wrapping int. Happy path: `Id = 42`. | `IsValid == true`; `Failures.IsEmpty` |
+| 2 | Same shape, sad path: `Id = 0`. | `IsValid == false`; `Failures.Length == 1`; `Failures[0].PropertyName == "Id"` |
+| 3 | `[Validate] X([property: NotEmpty] Username Name)` — single-prop value-object wrapping `string`. `[Theory]` over `("alice", true)` and `("", false)`. | matches expected |
+| 4 | `[Validate] X([property: InclusiveBetween(1, 100)] PageNumber Page)` — single-prop value-object wrapping int. `[Theory]` over `(50, true)`, `(0, false)`, `(101, false)`. | matches expected |
+
+Inline models declared in the test file. Each marked `[ZeroAlloc.ValueObjects.ValueObject]` and exposing a single public property.
+
+**Generator-snapshot** (`ValueObjectPropertyDiagnosticTests.cs`, 4 cases):
+
+| # | Source | Expected generated output / diagnostic |
+|---|---|---|
+| 1 | `[Validate] X([property: GreaterThan(0)] CustomerId Id)` where `CustomerId : [ValueObject] readonly partial struct { int Value }` | generated `.g.cs` contains `instance.Id.Value > 0`; no `ZV0016` diagnostic |
+| 2 | Same shape but `Id` is `int Id` (no value-object) — regression net | generated `.g.cs` contains `instance.Id > 0`; no diagnostic |
+| 3 | `[GreaterThan(0)] Money Total` where `Money : [ValueObject] { decimal Amount, string Currency }` | `ZV0016` Warning emitted; generated `.g.cs` keeps `instance.Total > 0` (no rewrite — downstream CS0019) |
+| 4 | `[Must(typeof(MyValidator))] CustomerId Id` — predicate validator on a single-prop value-object | generated `.g.cs` passes `instance.Id` (the wrapper) to the predicate — predicate-validator carve-out preserved |
+
+Existing tests (the ~937 already-shipped suite + the B2/B3 additions) act as the regression net for primitive-typed and class-typed paths.
+
+### Backward compatibility
+
+Strictly additive:
+
+- Class-typed and primitive-typed property emissions are byte-identical to today (`GetValueObjectUnwrapMember` returns `null`, generator falls through to current `propAccess` builder).
+- `[ZeroAlloc.ValueObjects.ValueObject]` doesn't currently fire any ZA.Validation behaviour — adopters who already have both packages and primitive-typed validated requests see no diff.
+- `ZV0016` is new; no existing code can have been firing it.
+
+SemVer: minor bump (`1.4.1` → `1.5.0`).
+
+## Out of scope
+
+- **Multi-property value-object support with `MemberOf` hint.** Backlog item if surfaced by a real consumer.
+- **Collection-element value-objects** (`IReadOnlyList<MyValueObject>` where `MyValueObject` is `[ValueObject]`). The B3 fix already handles the value-type element case for `[Validate]`-decorated elements; `[ValueObject]`-only elements would need an analogous unwrap rule at the nested-validator emission sites. Separate enhancement.
+- **Predicate-validator opt-in unwrap.** A future `[MustOnValue]` or similar attribute could request unwrap-before-predicate behaviour. Not in this PR.
+- **Coordinated `IValueObject<T>` marker interface in ZA.ValueObjects.** D-1's "right long-term API" — coordinated change across both packages. Not B1's concern.
+
+## Files touched (final count)
+
+- **MOD:** 1 generator file (`RuleEmitter.cs`) — ~30 LOC + 1 descriptor
+- **MOD:** 1 analyzer-release manifest
+- **NEW:** 2 test files — ~250 LOC (4 + 4 cases)
+- **MOD:** 2 doc files (`getting-started.md`, `diagnostics.md`)
+- **MOD:** `docs/backlog.md` — mark B1 shipped on release-PR merge
+
+Total commit footprint: ~300 LOC including tests.

--- a/docs/plans/2026-05-27-value-object-property-validators.md
+++ b/docs/plans/2026-05-27-value-object-property-validators.md
@@ -1,0 +1,919 @@
+# Value-Object-Aware Property Validators Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Ship ZeroAlloc.Validation 1.5.0 — built-in operand-taking validators (`[GreaterThan]`, `[NotEmpty]`, `[Matches]`, `[InclusiveBetween]`, etc.) accept `[ZeroAlloc.ValueObjects.ValueObject]`-typed properties directly by unwrapping through the single underlying member.
+
+**Architecture:** One shared helper `BuildPropertyAccess(modelParamName, prop)` replaces three inline `$"{modelParamName}.{prop.Name}"` constructions in `RuleEmitter.cs`. The helper detects single-property value-objects via the `[ValueObject]` FQN attribute and returns the unwrap expression (`instance.Prop.Value`); otherwise the raw access. Multi-property value-objects fall through with a new `ZV0016` Warning. Predicate validators (`[Must]`, `[CustomValidation]`, `[ValidateWith]`) don't participate by design.
+
+**Tech Stack:** .NET 10, Roslyn `IIncrementalGenerator`, xUnit, `CSharpGeneratorDriver` for snapshot tests.
+
+**Design doc:** `docs/plans/2026-05-27-value-object-property-validators-design.md` (committed at `f86db6e`).
+
+**Working branch:** `feat/value-object-aware-validators` (already created off `main`; design committed).
+
+---
+
+## Phase 0 — Orient (5 min)
+
+Skim three locations before touching code.
+
+### Task 0.1: Read the three rewrite sites
+
+**Files (read-only):**
+
+- `src/ZeroAlloc.Validation.Generator/RuleEmitter.cs:281-303` — `EmitPropertyRulesForProp` (lazy-allocation path). Builds `propAccess` at line 283, passes it to `BuildCondition`.
+- `src/ZeroAlloc.Validation.Generator/RuleEmitter.cs:415-440` — `EmitFlatPathPropertyRules` (zero-failure-allocation path). Builds `propAccess` at line 417 the same way.
+- `src/ZeroAlloc.Validation.Generator/RuleEmitter.cs:809-830` — `BuildPropertyValueExpr` (the `{value}` message-placeholder interpolator). Builds its own `access` at line 811.
+
+All three currently use `$"{modelParamName}.{prop.Name}"`. The fix replaces each with a call to a new shared helper.
+
+### Task 0.2: Read the existing `[ValueObject]` attribute + a sibling generator test
+
+**Files (read-only):**
+
+- `c:/Projects/Prive/ZeroAlloc/ZeroAlloc.ValueObjects/src/ZeroAlloc.ValueObjects/ValueObjectAttribute.cs` — the marker. FQN: `ZeroAlloc.ValueObjects.ValueObjectAttribute`. ZA.Validation detects it by FQN match, no runtime reference.
+- `tests/ZeroAlloc.Validation.Tests/Generator/StructValidationDiagnosticTests.cs` — same generator-snapshot test shape we want for the new diagnostic file.
+
+---
+
+## Phase 1 — Shared `BuildPropertyAccess` helper + integration TDD (45 min, 6 tasks)
+
+### Task 1.1: Create the integration test file with a single failing TypedId case
+
+**File (NEW):** `tests/ZeroAlloc.Validation.Tests/Integration/ValueObjectPropertyValidationTests.cs`
+
+For value-object declarations in tests, **don't** add a ZA.ValueObjects package reference. The detection rule is FQN-only on the attribute name — so declaring an attribute with the matching FQN in test code is sufficient. Simplest approach: hand-roll a local `ZeroAlloc.ValueObjects.ValueObjectAttribute` in the test compilation. Existing tests in `Integration/` may already do this — read `StructValidationTests.cs` and surrounding files to see if there's an established pattern. If not, the file declares its own.
+
+```csharp
+#pragma warning disable MA0048 // multiple types intentionally co-located
+
+using Xunit;
+using ZeroAlloc.Validation;
+
+namespace ZeroAlloc.Validation.Tests.Integration;
+
+public class ValueObjectPropertyValidationTests
+{
+    [Fact]
+    public void TypedId_GreaterThan_HappyPath_ReportsValid()
+    {
+        var validator = new PlaceOrderTypedCommandValidator();
+        var result = validator.Validate(new PlaceOrderTypedCommand(new CustomerId(42)));
+        Assert.True(result.IsValid);
+        Assert.True(result.Failures.IsEmpty);
+    }
+}
+
+// Local ValueObjectAttribute matching the ZA.ValueObjects FQN — no runtime ref needed.
+namespace ZeroAlloc.ValueObjects
+{
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct)]
+    public sealed class ValueObjectAttribute : System.Attribute { }
+}
+
+namespace ZeroAlloc.Validation.Tests.Integration
+{
+    [global::ZeroAlloc.ValueObjects.ValueObject]
+    public readonly partial struct CustomerId
+    {
+        public int Value { get; }
+        public CustomerId(int value) => Value = value;
+    }
+
+    [Validate]
+    public readonly record struct PlaceOrderTypedCommand(
+        [property: GreaterThan(0)] CustomerId CustomerId);
+}
+```
+
+Note: the `partial` keyword isn't strictly needed (no ZA.ValueObjects generator runs in tests; the struct is fully declared inline), but it matches the convention adopters will use. Keeping it makes the test feel realistic.
+
+### Task 1.2: Run — expect FAIL (CS0019 or similar) via test-assembly build error
+
+```bash
+cd c:/Projects/Prive/ZeroAlloc/ZeroAlloc.Validation
+dotnet test tests/ZeroAlloc.Validation.Tests -c Release --filter "FullyQualifiedName~ValueObjectPropertyValidationTests"
+```
+
+Expected: **BUILD FAIL** with `CS0019: Operator '<=' cannot be applied to operands of type 'CustomerId' and 'int'` (or similar — the exact operator depends on which validator the generator picks for `[GreaterThan(0)]`).
+
+This proves the bug exists in 1.4.1: the generator emits a primitive-typed comparison against the wrapper.
+
+If it builds and the test passes, the generator is somehow already handling this — stop and report; the bug premise needs re-validation.
+
+### Task 1.3: Implement the shared `BuildPropertyAccess` helper
+
+**File:** `src/ZeroAlloc.Validation.Generator/RuleEmitter.cs`
+
+**Step 1:** Add the two helpers near the bottom of the file, alongside `NeedsNullGuard` (shipped in 1.4.1):
+
+```csharp
+    private const string ValueObjectAttributeFqn = "ZeroAlloc.ValueObjects.ValueObjectAttribute";
+
+    /// <summary>
+    /// If <paramref name="type"/> is a single-property value-object (decorated
+    /// with <c>[ZeroAlloc.ValueObjects.ValueObject]</c> and declaring exactly one
+    /// public instance property), returns that property's name. Returns null for
+    /// everything else — class types, primitives, multi-property value-objects,
+    /// or types without the marker attribute.
+    /// </summary>
+    private static string? GetValueObjectUnwrapMember(ITypeSymbol type)
+    {
+        if (type is not INamedTypeSymbol named) return null;
+
+        var hasMarker = named.GetAttributes()
+            .Any(a => string.Equals(
+                a.AttributeClass?.ToDisplayString(),
+                ValueObjectAttributeFqn,
+                StringComparison.Ordinal));
+        if (!hasMarker) return null;
+
+        var properties = named.GetMembers()
+            .OfType<IPropertySymbol>()
+            .Where(p => !p.IsStatic && p.DeclaredAccessibility == Accessibility.Public)
+            .ToArray();
+
+        return properties.Length == 1 ? properties[0].Name : null;
+    }
+
+    /// <summary>
+    /// True when <paramref name="type"/> carries <c>[ZeroAlloc.ValueObjects.ValueObject]</c>,
+    /// regardless of property count. Used by the multi-property diagnostic (ZV0016)
+    /// to detect "this is a value-object that auto-unwrap can't help with."
+    /// </summary>
+    private static bool HasValueObjectAttribute(ITypeSymbol type) =>
+        type is INamedTypeSymbol named
+        && named.GetAttributes().Any(a => string.Equals(
+            a.AttributeClass?.ToDisplayString(),
+            ValueObjectAttributeFqn,
+            StringComparison.Ordinal));
+
+    /// <summary>
+    /// Builds the access expression for a property's value. When the property's
+    /// type is a single-property <c>[ValueObject]</c>, the expression unwraps
+    /// through that property (e.g. <c>instance.CustomerId.Value</c>). Otherwise
+    /// returns the raw access (<c>instance.CustomerId</c>).
+    /// </summary>
+    private static string BuildPropertyAccess(string modelParamName, IPropertySymbol prop)
+    {
+        var raw = $"{modelParamName}.{prop.Name}";
+        var unwrapMember = GetValueObjectUnwrapMember(prop.Type);
+        return unwrapMember is not null ? $"{raw}.{unwrapMember}" : raw;
+    }
+```
+
+**Step 2:** Replace the three inline `$"{modelParamName}.{propName}"` constructions:
+
+- `EmitPropertyRulesForProp` line 283: `var propAccess = BuildPropertyAccess(modelParamName, prop);` (drop `var propName = prop.Name;` if it's only used in the access — likely is, check the surrounding code; if it's used elsewhere keep it but read from `prop.Name` directly there)
+- `EmitFlatPathPropertyRules` line 417: same replacement
+- `BuildPropertyValueExpr` line 811: `var access = BuildPropertyAccess(modelParamName, prop);` (replaces the inline `$"{modelParamName}.{prop.Name}"`)
+
+Verify nothing else inside those methods depends on the raw (un-unwrapped) access — the test from Task 1.1 + the regression net in Phase 2 are the safety net.
+
+### Task 1.4: Run — expect the originally failing test now PASSES
+
+```bash
+dotnet test tests/ZeroAlloc.Validation.Tests -c Release --filter "FullyQualifiedName~ValueObjectPropertyValidationTests"
+```
+
+Expected: 1/1 pass.
+
+If the test passes but a different existing test fails, the helper introduced a regression somewhere. Run the full suite (next step) and diagnose.
+
+### Task 1.5: Run the FULL test suite — verify no regressions
+
+```bash
+dotnet test -c Release
+```
+
+Expected: every existing test passes. Primitive-typed and class-typed properties produce byte-identical output (helper returns the raw access for non-value-object types).
+
+### Task 1.6: Commit
+
+```bash
+git add src/ZeroAlloc.Validation.Generator/RuleEmitter.cs \
+        tests/ZeroAlloc.Validation.Tests/Integration/ValueObjectPropertyValidationTests.cs
+git commit -m "feat(generator): unwrap [ValueObject] properties in built-in validators
+
+Adds GetValueObjectUnwrapMember + BuildPropertyAccess helpers and
+routes the three propAccess construction sites in RuleEmitter
+through them. When a property's declared type carries
+[ZeroAlloc.ValueObjects.ValueObject] AND has exactly one public
+instance property, the access expression unwraps through that
+property (instance.CustomerId.Value instead of instance.CustomerId).
+Every built-in operand-taking validator participates uniformly.
+
+Predicate validators ([Must], [CustomValidation], [ValidateWith])
+naturally don't participate — they take the property's identity,
+not its operand-form access.
+
+Multi-property value-objects + the ZV0016 diagnostic land in a
+follow-up commit in the same release cycle."
+```
+
+---
+
+## Phase 2 — Integration regression net (15 min, 3 tasks)
+
+### Task 2.1: Add three more integration cases (sad path + string value-object + range)
+
+**File:** `tests/ZeroAlloc.Validation.Tests/Integration/ValueObjectPropertyValidationTests.cs`
+
+Inside the test class, after the existing `TypedId_GreaterThan_HappyPath_ReportsValid`, append:
+
+```csharp
+    [Fact]
+    public void TypedId_GreaterThan_SadPath_ReportsFailureOnTypedIdProperty()
+    {
+        var validator = new PlaceOrderTypedCommandValidator();
+        var result = validator.Validate(new PlaceOrderTypedCommand(new CustomerId(0)));
+        Assert.False(result.IsValid);
+        Assert.Equal(1, result.Failures.Length);
+        Assert.Equal(nameof(PlaceOrderTypedCommand.CustomerId), result.Failures[0].PropertyName);
+    }
+
+    [Theory]
+    [InlineData("alice", true)]
+    [InlineData("", false)]
+    public void StringValueObject_NotEmpty_Behaves(string raw, bool expectedValid)
+    {
+        var validator = new CreateUserCommandValidator();
+        var result = validator.Validate(new CreateUserCommand(new Username(raw)));
+        Assert.Equal(expectedValid, result.IsValid);
+    }
+
+    [Theory]
+    [InlineData(50, true)]
+    [InlineData(0, false)]
+    [InlineData(101, false)]
+    public void TypedId_InclusiveBetween_Behaves(int raw, bool expectedValid)
+    {
+        var validator = new GetPageCommandValidator();
+        var result = validator.Validate(new GetPageCommand(new PageNumber(raw)));
+        Assert.Equal(expectedValid, result.IsValid);
+    }
+```
+
+After the existing model declarations at the bottom of the file, append the new models inside the same `ZeroAlloc.Validation.Tests.Integration` namespace block (or alongside, depending on how the existing models are organised):
+
+```csharp
+[global::ZeroAlloc.ValueObjects.ValueObject]
+public readonly partial struct Username
+{
+    public string Value { get; }
+    public Username(string value) => Value = value;
+}
+
+[Validate]
+public readonly record struct CreateUserCommand(
+    [property: NotEmpty] Username Name);
+
+[global::ZeroAlloc.ValueObjects.ValueObject]
+public readonly partial struct PageNumber
+{
+    public int Value { get; }
+    public PageNumber(int value) => Value = value;
+}
+
+[Validate]
+public readonly record struct GetPageCommand(
+    [property: InclusiveBetween(1, 100)] PageNumber Page);
+```
+
+### Task 2.2: Run — expect 4/4 pass
+
+```bash
+dotnet test -c Release --filter "FullyQualifiedName~ValueObjectPropertyValidationTests"
+```
+
+Expected: 4/4 pass — the sad path proves the `PropertyName` is still the wrapper-property's name (not `CustomerId.Value`); the string + range tests prove the rewrite applies uniformly across validator categories.
+
+### Task 2.3: Commit
+
+```bash
+git add tests/ZeroAlloc.Validation.Tests/Integration/ValueObjectPropertyValidationTests.cs
+git commit -m "test(generator): sad path + string + range coverage for value-object unwrap"
+```
+
+---
+
+## Phase 3 — Generator-snapshot tests for emission shape (20 min, 3 tasks)
+
+### Task 3.1: Create the diagnostic-snapshot test file
+
+**File (NEW):** `tests/ZeroAlloc.Validation.Tests/Generator/ValueObjectPropertyDiagnosticTests.cs`
+
+```csharp
+using System;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+using ZeroAlloc.Validation;
+using ZeroAlloc.Validation.Generator;
+
+namespace ZeroAlloc.Validation.Tests.Generator;
+
+public class ValueObjectPropertyDiagnosticTests
+{
+    [Fact]
+    public void ValueObject_TypedId_Property_Rewrites_To_Unwrap_Member()
+    {
+        var source = """
+            using ZeroAlloc.Validation;
+            using ZeroAlloc.ValueObjects;
+            namespace TestModels;
+
+            [ValueObject]
+            public readonly partial struct CustomerId
+            {
+                public int Value { get; }
+                public CustomerId(int value) => Value = value;
+            }
+
+            [Validate]
+            public readonly record struct PlaceOrderCommand(
+                [property: GreaterThan(0)] CustomerId CustomerId);
+            """;
+
+        var result = RunGenerator(source);
+
+        Assert.Empty(result.Diagnostics);
+        var validatorSource = GetGeneratedSource(result, "PlaceOrderCommandValidator.g.cs");
+        Assert.Contains("instance.CustomerId.Value", validatorSource, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Primitive_Property_Still_Emits_Raw_Access()
+    {
+        var source = """
+            using ZeroAlloc.Validation;
+            namespace TestModels;
+
+            [Validate]
+            public readonly record struct PlaceOrderCommand(
+                [property: GreaterThan(0)] int CustomerId);
+            """;
+
+        var result = RunGenerator(source);
+
+        Assert.Empty(result.Diagnostics);
+        var validatorSource = GetGeneratedSource(result, "PlaceOrderCommandValidator.g.cs");
+        Assert.Contains("instance.CustomerId", validatorSource, StringComparison.Ordinal);
+        Assert.DoesNotContain("instance.CustomerId.Value", validatorSource, StringComparison.Ordinal);
+    }
+
+    private static string GetGeneratedSource(GeneratorDriverRunResult result, string filenameSuffix) =>
+        result.GeneratedTrees
+            .First(t => t.FilePath.EndsWith(filenameSuffix, StringComparison.Ordinal))
+            .ToString();
+
+    private static GeneratorDriverRunResult RunGenerator(string source)
+    {
+        // Add a stub ValueObjectAttribute matching the ZA.ValueObjects FQN so the
+        // generator's attribute-by-name lookup matches. No runtime reference to
+        // ZA.ValueObjects needed.
+        var valueObjectStub = """
+            namespace ZeroAlloc.ValueObjects
+            {
+                [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Struct)]
+                public sealed class ValueObjectAttribute : System.Attribute { }
+            }
+            """;
+
+        var compilation = CSharpCompilation.Create(
+            "TestAssembly",
+            new[] { CSharpSyntaxTree.ParseText(source), CSharpSyntaxTree.ParseText(valueObjectStub) },
+            new[]
+            {
+                MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+                MetadataReference.CreateFromFile(typeof(ValidateAttribute).Assembly.Location),
+            },
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        var generator = new ValidatorGenerator();
+        var driver = CSharpGeneratorDriver.Create(generator).RunGenerators(compilation);
+        return driver.GetRunResult();
+    }
+}
+```
+
+If the sibling `StructValidationDiagnosticTests.cs` uses a slightly different `RunGenerator` shape (e.g. collection-syntax `[ ... ]` for the array literals or `string.Equals` for ID comparisons), match that convention.
+
+### Task 3.2: Run — expect 2/2 pass
+
+```bash
+dotnet test -c Release --filter "FullyQualifiedName~ValueObjectPropertyDiagnosticTests"
+```
+
+Expected: 2/2 pass.
+
+- Case 1 confirms the rewrite kicks in for value-object properties.
+- Case 2 confirms the rewrite **doesn't** kick in for primitives — regression net.
+
+If case 2 fails (the substring `instance.CustomerId.Value` appears in the primitive-typed generated source), the helper's null-return branch is broken. Stop and report.
+
+### Task 3.3: Commit
+
+```bash
+git add tests/ZeroAlloc.Validation.Tests/Generator/ValueObjectPropertyDiagnosticTests.cs
+git commit -m "test(generator): emission-shape snapshot for value-object unwrap
+
+Cases:
+- value-object TypedId property rewrites to instance.Prop.Value
+- primitive property still emits raw instance.Prop (regression net)"
+```
+
+---
+
+## Phase 4 — `ZV0016` Warning for multi-property value-objects (30 min, 5 tasks)
+
+### Task 4.1: Add the failing diagnostic test (multi-property Money case)
+
+**File:** `tests/ZeroAlloc.Validation.Tests/Generator/ValueObjectPropertyDiagnosticTests.cs`
+
+Append after the existing two tests:
+
+```csharp
+    [Fact]
+    public void MultiProperty_ValueObject_With_BuiltIn_Validator_Fires_ZV0016()
+    {
+        var source = """
+            using ZeroAlloc.Validation;
+            using ZeroAlloc.ValueObjects;
+            namespace TestModels;
+
+            [ValueObject]
+            public readonly partial struct Money
+            {
+                public decimal Amount { get; }
+                public string Currency { get; }
+                public Money(decimal amount, string currency)
+                {
+                    Amount = amount;
+                    Currency = currency;
+                }
+            }
+
+            [Validate]
+            public readonly record struct PriceCommand(
+                [property: GreaterThan(0)] Money Total);
+            """;
+
+        var result = RunGenerator(source);
+
+        Assert.Contains(result.Diagnostics, d => string.Equals(d.Id, "ZV0016", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void SingleProperty_ValueObject_Does_Not_Fire_ZV0016()
+    {
+        var source = """
+            using ZeroAlloc.Validation;
+            using ZeroAlloc.ValueObjects;
+            namespace TestModels;
+
+            [ValueObject]
+            public readonly partial struct CustomerId
+            {
+                public int Value { get; }
+                public CustomerId(int value) => Value = value;
+            }
+
+            [Validate]
+            public readonly record struct PlaceOrderCommand(
+                [property: GreaterThan(0)] CustomerId CustomerId);
+            """;
+
+        var result = RunGenerator(source);
+
+        Assert.DoesNotContain(result.Diagnostics, d => string.Equals(d.Id, "ZV0016", StringComparison.Ordinal));
+    }
+```
+
+### Task 4.2: Run — expect 1 FAIL (`Fires_ZV0016`) + 1 PASS (`Does_Not_Fire`)
+
+```bash
+dotnet test -c Release --filter "FullyQualifiedName~ValueObjectPropertyDiagnosticTests"
+```
+
+Expected: 3/4 pass — the two Phase 3 cases stay green, `Does_Not_Fire_ZV0016` passes trivially (no diagnostic exists yet), `Fires_ZV0016` fails because the descriptor + emit aren't in place.
+
+### Task 4.3: Add the `ZV0016` `DiagnosticDescriptor`
+
+**File:** `src/ZeroAlloc.Validation.Generator/ValidatorGenerator.cs` (where the existing `ZV0011..ZV0015` descriptors live)
+
+Insert after `ZV0015`:
+
+```csharp
+    private static readonly DiagnosticDescriptor ZV0016 = new DiagnosticDescriptor(
+        id: "ZV0016",
+        title: "Value-object with multiple properties can't be auto-unwrapped",
+        messageFormat:
+            "Property '{0}' of type '{1}' carries a built-in validator but '{1}' is a multi-property value-object ({2} properties). " +
+            "Auto-unwrap requires exactly one underlying property. " +
+            "Either declare the validator on a single-property value-object, or use [Must] / [CustomValidation] with a custom predicate.",
+        category: "ZeroAlloc.Validation",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+```
+
+### Task 4.4: Emit `ZV0016` from the rule-emission entry points
+
+**File:** `src/ZeroAlloc.Validation.Generator/RuleEmitter.cs`
+
+The diagnostic fires when a property has at least one built-in validator rule AND its type carries `[ValueObject]` AND the unwrap helper returns `null` (i.e. multi-property or weird shape). The natural place is right at the rule-emission entry where `propAccess` is constructed.
+
+`RuleEmitter` is called from `ValidatorGenerator.Emit` with a `SourceProductionContext ctx`. The current public entry points (`EmitPropertyRulesForProp`, `EmitFlatPathPropertyRules`) don't receive `ctx`. Two options:
+
+1. **Thread `ctx` through** — change the method signatures to accept `SourceProductionContext ctx` and use `ctx.ReportDiagnostic`.
+2. **Collect diagnostics into a List<Diagnostic>** that the caller reports.
+
+Pick (1) — matches the pattern used in `EmitPropertyRulesForProp`'s caller chain. The methods need a `SourceProductionContext` parameter; pipe it from `Emit` down through `EmitFlatPath` / `EmitLazyPath` to the per-property emission methods.
+
+Specifically, in `EmitPropertyRulesForProp` (lazy path):
+
+```csharp
+private static void EmitPropertyRulesForProp(
+    SourceProductionContext ctx,   // ← new parameter
+    StringBuilder sb,
+    IPropertySymbol prop,
+    List<AttributeData> rules,
+    string modelParamName)
+{
+    var propAccess = BuildPropertyAccess(modelParamName, prop);
+
+    // ZV0016: multi-property value-object can't be auto-unwrapped.
+    if (rules.Count > 0
+        && HasValueObjectAttribute(prop.Type)
+        && GetValueObjectUnwrapMember(prop.Type) is null)
+    {
+        var propCount = ((INamedTypeSymbol)prop.Type).GetMembers()
+            .OfType<IPropertySymbol>()
+            .Count(p => !p.IsStatic && p.DeclaredAccessibility == Accessibility.Public);
+        ctx.ReportDiagnostic(Diagnostic.Create(
+            ZV0016,
+            prop.Locations.FirstOrDefault() ?? Location.None,
+            prop.Name, prop.Type.Name, propCount));
+    }
+
+    // …existing emission code continues unchanged…
+}
+```
+
+Mirror the same diagnostic-fire-block in `EmitFlatPathPropertyRules`. Walk back up the call chain (`Emit` → `EmitFlatPath` / `EmitLazyPath` → these per-property methods) and add `SourceProductionContext ctx` to each signature.
+
+`ZV0016` is declared in `ValidatorGenerator.cs` but the emission happens in `RuleEmitter.cs` — either expose it as `internal static readonly`, or move it to `RuleEmitter.cs`. The existing `ZV0011..ZV0015` are emitted from various places; check whether they're already `internal` and follow the same access modifier.
+
+### Task 4.5: Update `AnalyzerReleases.Unshipped.md` + run + commit
+
+**File:** `src/ZeroAlloc.Validation.Generator/AnalyzerReleases.Unshipped.md`
+
+Append (or extend the existing `### New Rules` table):
+
+```markdown
+### New Rules
+
+Rule ID | Category             | Severity | Notes
+--------|----------------------|----------|------------------------------
+ZV0016  | ZeroAlloc.Validation | Warning  | Multi-property value-object can't be auto-unwrapped
+```
+
+Run:
+
+```bash
+dotnet test -c Release --filter "FullyQualifiedName~ValueObjectPropertyDiagnosticTests"
+```
+
+Expected: 4/4 pass.
+
+```bash
+dotnet test -c Release
+```
+
+Expected: full suite green.
+
+```bash
+git add src/ZeroAlloc.Validation.Generator/RuleEmitter.cs \
+        src/ZeroAlloc.Validation.Generator/ValidatorGenerator.cs \
+        src/ZeroAlloc.Validation.Generator/AnalyzerReleases.Unshipped.md \
+        tests/ZeroAlloc.Validation.Tests/Generator/ValueObjectPropertyDiagnosticTests.cs
+git commit -m "feat(generator): ZV0016 warning for multi-property value-objects
+
+Auto-unwrap (the B1 ergonomics shipped above) requires the
+[ValueObject] type to declare exactly one public property. Multi-
+property value-objects like Money { Amount, Currency } can't be
+unambiguously unwrapped; the generator falls through to its current
+behaviour (which produces the existing CS0019 from comparing the
+wrapper to a primitive) and additionally fires ZV0016 to tell the
+adopter why.
+
+Threads SourceProductionContext through the per-property emission
+methods so diagnostics can be reported from the rule-emission entry
+points."
+```
+
+---
+
+## Phase 5 — `[Must]` predicate carve-out regression net (15 min, 3 tasks)
+
+### Task 5.1: Add the `[Must]` regression test
+
+**File:** `tests/ZeroAlloc.Validation.Tests/Generator/ValueObjectPropertyDiagnosticTests.cs`
+
+Append:
+
+```csharp
+    [Fact]
+    public void Must_Predicate_On_ValueObject_Property_Passes_Wrapper_Not_Unwrap()
+    {
+        var source = """
+            using ZeroAlloc.Validation;
+            using ZeroAlloc.ValueObjects;
+            namespace TestModels;
+
+            [ValueObject]
+            public readonly partial struct CustomerId
+            {
+                public int Value { get; }
+                public CustomerId(int value) => Value = value;
+            }
+
+            public static class MustHelpers
+            {
+                public static bool IsKnown(CustomerId id) => id.Value > 0;
+            }
+
+            [Validate]
+            public readonly record struct PlaceOrderCommand(
+                [property: Must(typeof(MustHelpers), nameof(MustHelpers.IsKnown))] CustomerId CustomerId);
+            """;
+
+        var result = RunGenerator(source);
+
+        Assert.Empty(result.Diagnostics);
+        var validatorSource = GetGeneratedSource(result, "PlaceOrderCommandValidator.g.cs");
+        // The Must predicate receives the wrapper, NOT instance.CustomerId.Value.
+        Assert.Contains("instance.CustomerId", validatorSource, StringComparison.Ordinal);
+        Assert.DoesNotContain("instance.CustomerId.Value", validatorSource, StringComparison.Ordinal);
+    }
+```
+
+The exact `[Must]` attribute signature may differ from what's shown here — read `src/ZeroAlloc.Validation/Attributes/MustAttribute.cs` to confirm. Adjust the test source accordingly so it represents the canonical `[Must]` usage pattern.
+
+### Task 5.2: Run — expect PASS (already covered by design, no code change)
+
+```bash
+dotnet test -c Release --filter "FullyQualifiedName~ValueObjectPropertyDiagnosticTests"
+```
+
+Expected: 5/5 pass — `[Must]` doesn't route through `propAccess`, so the rewrite never touches it.
+
+If this test fails (i.e. the rewrite DID touch the `[Must]` emission), the implementation accidentally applies the rewrite somewhere that's not a built-in operand-taking validator. Investigate: trace where the `[Must]` validator emits its predicate call; if it uses `propAccess`, the carve-out needs an explicit check (skip `BuildPropertyAccess` rewrite when the attribute is `MustAttribute` / `CustomValidationAttribute` / `ValidateWithAttribute`).
+
+If a fix is needed, the simplest shape is to filter at the `BuildPropertyAccess` call site:
+
+```csharp
+// Build raw access; predicate validators pass it through unchanged.
+var rawAccess = $"{modelParamName}.{prop.Name}";
+// Pass to emission, which decides whether to unwrap per-attribute (it shouldn't —
+// but if the implementation conflates them, fix here).
+```
+
+Adjust and retry.
+
+### Task 5.3: Commit
+
+```bash
+git add tests/ZeroAlloc.Validation.Tests/Generator/ValueObjectPropertyDiagnosticTests.cs
+git commit -m "test(generator): [Must] predicate carve-out — receives wrapper, not unwrap"
+```
+
+---
+
+## Phase 6 — Docs (15 min, 3 tasks)
+
+### Task 6.1: Update `docs/getting-started.md`
+
+**File:** `docs/getting-started.md`
+
+Find the section introducing `[Validate]` (search for the literal `[Validate]` or the first code sample). Insert a new subsection — placement: after the basic `[Validate]` introduction, before the `[ValidateWith]` / nested-validators section.
+
+```markdown
+### Validating value-object properties
+
+`[Validate]` request types can carry properties typed as
+[`ZeroAlloc.ValueObjects`](https://www.nuget.org/packages/ZeroAlloc.ValueObjects)
+value-objects, and the built-in validators unwrap to the value-object's underlying
+property automatically:
+
+```csharp
+[ValueObject]
+public readonly partial struct CustomerId
+{
+    public int Value { get; }
+    public CustomerId(int value) => Value = value;
+}
+
+[Validate]
+public readonly record struct PlaceOrderCommand(
+    [property: GreaterThan(0)] CustomerId CustomerId);
+```
+
+`[GreaterThan(0)]` here compares against `CustomerId.Value` — the wrapper is
+transparently unwrapped during validation. Same applies to `[InclusiveBetween]`,
+`[NotEmpty]`, `[Matches]`, `[Length]`, and every other built-in operand-taking
+validator.
+
+**Single-property requirement.** Auto-unwrap works for value-objects that
+declare exactly one public property (the typical "typed id" shape). Multi-
+property value-objects like `Money { Amount, Currency }` aren't unwrapped —
+the generator fires `ZV0016` and the build fails on the underlying type
+mismatch. Use a `[Must]` or `[CustomValidation]` predicate to validate
+multi-property value-objects against a custom rule.
+
+**Predicate carve-out.** `[Must]`, `[CustomValidation]`, and `[ValidateWith]`
+receive the value-object itself (the wrapper), not the unwrapped value. The
+user-provided predicate signature dictates which form the value arrives in.
+```
+
+### Task 6.2: Add `ZV0016` to `docs/diagnostics.md`
+
+**File:** `docs/diagnostics.md`
+
+Add a row to the summary table (search for `ZV0014` / `ZV0015` to find the table) and a `## ZV0016` section between `ZV0015` and the end (or wherever the numeric order dictates). Style-match existing entries (colon-terminated bold labels per the B2 follow-up: `**Severity:**`, `**Title:**`, `**When fired:**`, `**Fix:**`).
+
+```markdown
+## ZV0016 — Multi-property value-object can't be auto-unwrapped
+
+**Severity:** Warning
+
+**Title:** Value-object with multiple properties can't be auto-unwrapped
+
+**When fired:** A property's type is decorated with `[ZeroAlloc.ValueObjects.ValueObject]`,
+the property carries at least one built-in operand-taking validator (e.g.
+`[GreaterThan]`, `[NotEmpty]`, `[Matches]`), and the value-object declares
+more than one public instance property. The generator can't pick a single
+underlying member to unwrap to.
+
+**Fix:** Pick one of:
+
+- Use a single-property value-object (typical TypedId shape — one `Value`
+  property wrapping a primitive).
+- Replace the built-in validator with `[Must]` or `[CustomValidation]` and
+  validate the wrapper directly.
+
+**Example that fires the warning:**
+
+```csharp
+[ValueObject]
+public readonly partial struct Money
+{
+    public decimal Amount { get; }
+    public string Currency { get; }
+}
+
+[Validate]
+public readonly record struct PriceCommand(
+    [property: GreaterThan(0)] Money Total);   // ZV0016
+```
+
+**Suppressing.** This warning typically accompanies a CS0019 (type mismatch)
+that blocks the build anyway. If you have a legitimate reason to compile a
+multi-property value-object through a built-in validator path (rare; usually
+indicates a design issue), suppress with `#pragma warning disable ZV0016` or
+`<NoWarn>$(NoWarn);ZV0016</NoWarn>`.
+```
+
+### Task 6.3: Commit
+
+```bash
+git add docs/getting-started.md docs/diagnostics.md
+git commit -m "docs: ZV0016 + value-object validator unwrap section"
+```
+
+---
+
+## Phase 7 — Backlog + ship (15 min, 4 tasks)
+
+### Task 7.1: Run the full suite one final time
+
+```bash
+cd c:/Projects/Prive/ZeroAlloc/ZeroAlloc.Validation
+dotnet test -c Release
+```
+
+Expected: every test passes — the 4 integration cases + the 5 generator-snapshot cases + every existing test.
+
+### Task 7.2: Push + open the PR
+
+```bash
+git push -u origin feat/value-object-aware-validators
+gh pr create \
+  --title "feat(generator): unwrap [ValueObject] properties in built-in validators" \
+  --body "$(cat <<'EOF'
+## Summary
+
+Closes backlog B1. Built-in operand-taking validators (``[GreaterThan]``, ``[NotEmpty]``, ``[InclusiveBetween]``, ``[Matches]``, ``[Length]``, …) now unwrap properties whose type is a single-property ``[ZeroAlloc.ValueObjects.ValueObject]``. The validator emits its comparison/regex/length code against ``instance.Prop.Value`` instead of ``instance.Prop``, so this becomes legal:
+
+```csharp
+[Validate]
+public readonly record struct PlaceOrderCommand(
+    [property: GreaterThan(0)] CustomerId CustomerId,
+    [property: NotEmpty] Username Name);
+```
+
+Previously the only workaround was to drop value-objects from request types and re-wrap manually in the handler.
+
+Surfaced 2026-05-26 building the ``za-vertical-slice`` template. The template's six request types currently carry raw ``int`` / ``decimal`` properties for exactly this reason; once 1.5.0 propagates, a follow-up template PR can adopt typed properties.
+
+## What changed
+
+- Two new private helpers in ``RuleEmitter.cs``:
+  - ``GetValueObjectUnwrapMember(ITypeSymbol)`` — returns the underlying property name when the type is a single-property ``[ValueObject]``; ``null`` otherwise.
+  - ``BuildPropertyAccess(modelParamName, prop)`` — central access-expression builder. Returns ``instance.Prop.Value`` for value-objects, ``instance.Prop`` otherwise.
+- Three rewrite sites consolidated through ``BuildPropertyAccess``:
+  - ``EmitPropertyRulesForProp`` (lazy-allocation path)
+  - ``EmitFlatPathPropertyRules`` (zero-failure-allocation path)
+  - ``BuildPropertyValueExpr`` (the ``{value}`` message-placeholder interpolator)
+- New ``ZV0016`` Warning when a property carries a built-in validator and the type is a multi-property ``[ValueObject]`` (e.g. ``Money { Amount, Currency }``). Generator falls through to current behaviour; CS0019 still blocks the build but ZV0016 explains why auto-unwrap didn't help.
+- 4 integration tests covering: TypedId happy + sad paths, string value-object ``[NotEmpty]`` ``[Theory]``, range validator on a TypedId.
+- 5 generator-snapshot tests covering: value-object rewrite present, primitive rewrite absent (regression net), multi-property ZV0016 fires, single-property doesn't fire, ``[Must]`` predicate carve-out.
+
+## Decisions ([design doc](docs/plans/2026-05-27-value-object-property-validators-design.md))
+
+- **FQN-based attribute detection** — ZA.Validation never references ZA.ValueObjects at runtime; only matches ``ZeroAlloc.ValueObjects.ValueObjectAttribute`` by metadata name. Adopters who don't use ZA.ValueObjects pay nothing.
+- **Single-property requirement.** Multi-property value-objects fall through with ``ZV0016`` — the user picks either a single-property shape or a custom predicate. Considered ``MemberOf`` hint on the validator attribute; YAGNI-deferred.
+- **Predicate validator carve-out.** ``[Must]``, ``[CustomValidation]``, ``[ValidateWith]`` receive the wrapper, not the unwrap — their user-controlled signatures dictate the type. Falls out naturally from rewriting at ``propAccess`` (which predicate validators don't consume).
+
+## SemVer
+
+``1.4.1`` → ``1.5.0`` (additive minor — new shapes compile that previously didn't; existing class/primitive consumers see byte-identical generator output).
+
+## Test plan
+
+- [x] ``dotnet test -c Release`` — all green locally on net8/net9/net10 (existing ~940 + 9 new = ~950)
+- [ ] CI — green on this PR
+- [ ] Follow-up after 1.5.0 propagates: ``ZeroAlloc.Templates`` migrates ``za-vertical-slice``'s 6 request types from raw ``int`` / ``decimal`` properties to typed ``CustomerId`` / ``OrderId`` / etc., closing the original friction loop.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+### Task 7.3: Watch CI
+
+```bash
+gh pr checks --watch
+```
+
+Expected outcomes:
+
+- ``build`` green
+- ``aot-smoke`` green — the helper change has no AOT impact (all reflection happens at generator time, never at runtime)
+- ``api-compat / api-compat`` green — strictly additive API surface
+
+If anything is red, diagnose on-branch. Possible failure modes: snapshot drift in another generator test that wasn't aware the access-expression construction was consolidated; the ``[Must]`` carve-out test catching a latent rewrite where the implementation conflates predicate and operand validators.
+
+### Task 7.4: After merge — mark B1 ✅ shipped in `docs/backlog.md`
+
+After CI lands green:
+
+```bash
+gh pr merge --admin --squash --delete-branch
+```
+
+Release-please opens ``chore(main): release 1.5.0``. Admin-merge that too. Verify NuGet propagation (2-5 min):
+
+```bash
+curl -s "https://api.nuget.org/v3-flatcontainer/zeroalloc.validation/index.json" \
+  | python -c "import sys, json; v = json.load(sys.stdin)['versions']; print('latest:', v[-1])"
+```
+
+Expected: ``latest: 1.5.0``.
+
+**B1 backlog hygiene** — strike B1 in ``docs/backlog.md`` with the same pattern B2 / B3 used (strikethrough heading + ``— ✅ shipped 1.5.0 (2026-05-27)`` + prepend a Shipped block; original body kept in ``<details>``). Commit on ``main`` with:
+
+```
+docs(backlog): mark B1 shipped (1.5.0)
+```
+
+---
+
+## Verification checklist
+
+- [ ] **Phase 1:** Value-object TypedId compiles + validates; helper returns underlying property name; ``BuildPropertyAccess`` consolidates three sites.
+- [ ] **Phase 2:** Sad path reports ``PropertyName`` as the wrapper-property name (not ``CustomerId.Value``); string + range validators participate in the rewrite uniformly.
+- [ ] **Phase 3:** Generated ``.g.cs`` contains ``instance.Prop.Value`` for value-object properties; contains ``instance.Prop`` (no ``.Value``) for primitives — regression net.
+- [ ] **Phase 4:** ``ZV0016`` Warning fires on multi-property value-objects, doesn't fire on single-property ones.
+- [ ] **Phase 5:** ``[Must]`` predicate carve-out: generated ``.g.cs`` passes the wrapper to the predicate, NOT the unwrap.
+- [ ] **Phase 6:** ``docs/getting-started.md`` callout + ``docs/diagnostics.md`` ZV0016 entry landed.
+- [ ] **Phase 7:** CI green, admin-merged, release-please cuts 1.5.0, NuGet propagates, B1 marked shipped in backlog.
+
+## Out of scope (deferred)
+
+- **Multi-property value-object support** via a ``MemberOf`` hint or similar. ZV0016 documents the limit; if a real consumer needs it, separate brainstorm.
+- **Collection-element value-objects** (``IReadOnlyList<MyValueObject>`` where elements carry ``[ValueObject]``). The B3 fix already covered the value-type collection-element case for ``[Validate]``-decorated elements; ``[ValueObject]``-only elements would need an analogous unwrap rule at the nested-validator emission sites. Separate enhancement.
+- **Predicate-validator opt-in unwrap** (``[MustOnValue]`` or similar). Not in this PR; users currently opt in/out via their predicate signature.
+- **Template migration follow-through** — ``za-vertical-slice`` request types stay on raw ``int`` / ``decimal`` until 1.5.0 propagates to NuGet, then a follow-up PR in ``ZeroAlloc.Templates`` adopts typed properties.

--- a/src/ZeroAlloc.Validation.Generator/AnalyzerReleases.Unshipped.md
+++ b/src/ZeroAlloc.Validation.Generator/AnalyzerReleases.Unshipped.md
@@ -10,3 +10,4 @@ ZV0012 | ZeroAlloc.Validation | Error | Invalid [ValidateWith] validator type
 ZV0013 | ZeroAlloc.Validation | Error | Invalid [CustomValidation] method signature
 ZV0014 | ZeroAlloc.Validation | Warning | [Validate] on non-readonly struct
 ZV0015 | ZeroAlloc.Validation | Error | Duplicate pipeline behavior Order
+ZV0016 | ZeroAlloc.Validation | Warning | Multi-property value-object can't be auto-unwrapped

--- a/src/ZeroAlloc.Validation.Generator/RuleEmitter.cs
+++ b/src/ZeroAlloc.Validation.Generator/RuleEmitter.cs
@@ -285,6 +285,7 @@ internal static class RuleEmitter
         var propName = prop.Name;
         var displayName = GetDisplayName(prop) ?? propName;
         var propAccess = BuildPropertyAccess(modelParamName, prop);
+        var rawPropAccess = $"{modelParamName}.{prop.Name}";
         var stopMode = HasStopOnFirstFailure(prop);
 
         ReportZV0016IfApplicable(ctx, prop, rules);
@@ -296,7 +297,7 @@ internal static class RuleEmitter
             var prefix = (stopMode && i > 0) ? "        else if" : "        if";
             var message = ResolveMessage(attr, fqn, displayName) ?? GetDefaultMessage(fqn, attr, displayName);
             var propTypeFullName = GetNullableUnwrappedFullTypeName(prop);
-            var condition = BuildCondition(fqn, attr, propAccess, propTypeFullName, modelParamName, prop.Type);
+            var condition = BuildCondition(fqn, attr, propAccess, propTypeFullName, modelParamName, prop.Type, rawPropAccess);
             var propertyValueExpr = HasPropertyValuePlaceholder(message) ? BuildPropertyValueExpr(prop, modelParamName) : null;
             var whenMethod   = GetWhen(attr);
             var unlessMethod = GetUnless(attr);
@@ -423,6 +424,7 @@ internal static class RuleEmitter
         var propName = prop.Name;
         var displayName = GetDisplayName(prop) ?? propName;
         var propAccess = BuildPropertyAccess(modelParamName, prop);
+        var rawPropAccess = $"{modelParamName}.{prop.Name}";
         var stopMode = HasStopOnFirstFailure(prop);
 
         ReportZV0016IfApplicable(ctx, prop, rules);
@@ -434,7 +436,7 @@ internal static class RuleEmitter
             var prefix = (stopMode && i > 0) ? "        else if" : "        if";
             var message = ResolveMessage(attr, fqn, displayName) ?? GetDefaultMessage(fqn, attr, displayName);
             var propTypeFullName = GetNullableUnwrappedFullTypeName(prop);
-            var condition = BuildCondition(fqn, attr, propAccess, propTypeFullName, modelParamName, prop.Type);
+            var condition = BuildCondition(fqn, attr, propAccess, propTypeFullName, modelParamName, prop.Type, rawPropAccess);
             var propertyValueExpr = HasPropertyValuePlaceholder(message) ? BuildPropertyValueExpr(prop, modelParamName) : null;
             var whenMethod   = GetWhen(attr);
             var unlessMethod = GetUnless(attr);
@@ -651,8 +653,16 @@ internal static class RuleEmitter
         return attr.ConstructorArguments[index].Type?.SpecialType == Microsoft.CodeAnalysis.SpecialType.System_String;
     }
 
-    private static string BuildCondition(string fqn, AttributeData attr, string access, string propTypeFullName = "", string modelParamName = "instance", ITypeSymbol? propType = null) =>
-        fqn switch
+    private static string BuildCondition(string fqn, AttributeData attr, string access, string propTypeFullName = "", string modelParamName = "instance", ITypeSymbol? propType = null, string? rawAccess = null)
+    {
+        // Predicate-style validators (e.g. [Must]) pass the property value as an argument
+        // to a user-defined method whose parameter type matches the declared property type.
+        // For value-object properties, the access string is unwrapped (e.g. instance.Id.Value),
+        // which is correct for built-in operand validators (GreaterThan, NotEmpty, ...) but
+        // wrong for predicates — the user's method expects the wrapper. Predicate branches
+        // therefore use rawAccess (the un-unwrapped form) when provided.
+        var rawForPredicate = rawAccess ?? access;
+        return fqn switch
         {
             NotNullFqn               => $"{access} is null",
             NotEmptyFqn              => BuildNotEmptyCondition(access, propType),
@@ -678,9 +688,10 @@ internal static class RuleEmitter
             IsInEnumFqn              => $"!global::System.Enum.IsDefined(typeof({propTypeFullName}), {access})",
             IsEnumNameFqn            => $"!global::System.Enum.IsDefined(typeof({GetTypeArgFullName(attr, 0)}), {access})",
             PrecisionScaleFqn        => $"global::ZeroAlloc.Validation.Internal.DecimalValidator.ExceedsPrecisionScale({access}, {GetIntArg(attr, 0)}, {GetIntArg(attr, 1)})",
-            MustFqn                  => $"!{modelParamName}.{GetStringArg(attr, 0)}({access})",
+            MustFqn                  => $"!{modelParamName}.{GetStringArg(attr, 0)}({rawForPredicate})",
             _                        => "false"
         };
+    }
 
     private static string GetDefaultMessage(string fqn, AttributeData attr, string propName) =>
         fqn switch

--- a/src/ZeroAlloc.Validation.Generator/RuleEmitter.cs
+++ b/src/ZeroAlloc.Validation.Generator/RuleEmitter.cs
@@ -280,7 +280,7 @@ internal static class RuleEmitter
     {
         var propName = prop.Name;
         var displayName = GetDisplayName(prop) ?? propName;
-        var propAccess = $"{modelParamName}.{propName}";
+        var propAccess = BuildPropertyAccess(modelParamName, prop);
         var stopMode = HasStopOnFirstFailure(prop);
 
         for (int i = 0; i < rules.Count; i++)
@@ -414,7 +414,7 @@ internal static class RuleEmitter
     {
         var propName = prop.Name;
         var displayName = GetDisplayName(prop) ?? propName;
-        var propAccess = $"{modelParamName}.{propName}";
+        var propAccess = BuildPropertyAccess(modelParamName, prop);
         var stopMode = HasStopOnFirstFailure(prop);
 
         for (int i = 0; i < rules.Count; i++)
@@ -808,7 +808,7 @@ internal static class RuleEmitter
 
     private static string BuildPropertyValueExpr(IPropertySymbol prop, string modelParamName)
     {
-        var access = $"{modelParamName}.{prop.Name}";
+        var access = BuildPropertyAccess(modelParamName, prop);
         var type = prop.Type;
 
         // Nullable value type: int?, double?, etc.
@@ -970,4 +970,57 @@ internal static class RuleEmitter
     private static bool NeedsNullGuard(ITypeSymbol type) =>
         !type.IsValueType
         || type.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T;
+
+    private const string ValueObjectAttributeFqn = "ZeroAlloc.ValueObjects.ValueObjectAttribute";
+
+    /// <summary>
+    /// If <paramref name="type"/> is a single-property value-object (decorated
+    /// with <c>[ZeroAlloc.ValueObjects.ValueObject]</c> and declaring exactly one
+    /// public instance property), returns that property's name. Returns null for
+    /// everything else — class types, primitives, multi-property value-objects,
+    /// or types without the marker attribute.
+    /// </summary>
+    private static string? GetValueObjectUnwrapMember(ITypeSymbol type)
+    {
+        if (type is not INamedTypeSymbol named) return null;
+
+        var hasMarker = named.GetAttributes()
+            .Any(a => string.Equals(
+                a.AttributeClass?.ToDisplayString(),
+                ValueObjectAttributeFqn,
+                StringComparison.Ordinal));
+        if (!hasMarker) return null;
+
+        var properties = named.GetMembers()
+            .OfType<IPropertySymbol>()
+            .Where(p => !p.IsStatic && p.DeclaredAccessibility == Accessibility.Public)
+            .ToArray();
+
+        return properties.Length == 1 ? properties[0].Name : null;
+    }
+
+    /// <summary>
+    /// True when <paramref name="type"/> carries <c>[ZeroAlloc.ValueObjects.ValueObject]</c>,
+    /// regardless of property count. Used by the multi-property diagnostic (ZV0016)
+    /// to detect "this is a value-object that auto-unwrap can't help with."
+    /// </summary>
+    private static bool HasValueObjectAttribute(ITypeSymbol type) =>
+        type is INamedTypeSymbol named
+        && named.GetAttributes().Any(a => string.Equals(
+            a.AttributeClass?.ToDisplayString(),
+            ValueObjectAttributeFqn,
+            StringComparison.Ordinal));
+
+    /// <summary>
+    /// Builds the access expression for a property's value. When the property's
+    /// type is a single-property <c>[ValueObject]</c>, the expression unwraps
+    /// through that property (e.g. <c>instance.CustomerId.Value</c>). Otherwise
+    /// returns the raw access (<c>instance.CustomerId</c>).
+    /// </summary>
+    private static string BuildPropertyAccess(string modelParamName, IPropertySymbol prop)
+    {
+        var raw = $"{modelParamName}.{prop.Name}";
+        var unwrapMember = GetValueObjectUnwrapMember(prop.Type);
+        return unwrapMember is not null ? $"{raw}.{unwrapMember}" : raw;
+    }
 }

--- a/src/ZeroAlloc.Validation.Generator/RuleEmitter.cs
+++ b/src/ZeroAlloc.Validation.Generator/RuleEmitter.cs
@@ -57,7 +57,7 @@ internal static class RuleEmitter
         prop.GetAttributes().Any(a =>
             string.Equals(a.AttributeClass?.ToDisplayString(), StopOnFirstFailureFqn, StringComparison.Ordinal));
 
-    public static void EmitValidateBody(StringBuilder sb, INamedTypeSymbol classSymbol, string modelParamName = "instance")
+    public static void EmitValidateBody(StringBuilder sb, INamedTypeSymbol classSymbol, string modelParamName = "instance", SourceProductionContext? ctx = null)
     {
         var skipWhenMethod = GetSkipWhenMethod(classSymbol);
         if (skipWhenMethod is not null)
@@ -79,9 +79,9 @@ internal static class RuleEmitter
         bool validatorStop = GetBoolNamedArg(validateAttr, "StopOnFirstFailure");
 
         if (hasNested)
-            EmitNestedPath(sb, classSymbol, byProperty, nestedProperties, collectionProperties, customMethods, modelParamName, validatorStop, totalDirectRules);
+            EmitNestedPath(sb, classSymbol, byProperty, nestedProperties, collectionProperties, customMethods, modelParamName, validatorStop, totalDirectRules, ctx);
         else
-            EmitFlatPath(sb, byProperty, totalDirectRules, modelParamName, validatorStop);
+            EmitFlatPath(sb, byProperty, totalDirectRules, modelParamName, validatorStop, ctx);
     }
 
     private static List<(IPropertySymbol Property, List<AttributeData> Rules)> CollectPropertyRules(INamedTypeSymbol classSymbol)
@@ -111,20 +111,21 @@ internal static class RuleEmitter
         List<string> customMethods,
         string modelParamName,
         bool validatorStop,
-        int totalDirectRules)
+        int totalDirectRules,
+        SourceProductionContext? ctx)
     {
         sb.AppendLine($"        var _buf = new global::ZeroAlloc.Validation.Internal.FailureBuffer({totalDirectRules});");
         sb.AppendLine();
 
         if (!validatorStop)
         {
-            EmitPropertyRulesWithAdd(sb, byProperty, modelParamName);
+            EmitPropertyRulesWithAdd(sb, byProperty, modelParamName, ctx);
             EmitNestedValidators(sb, nestedProperties, modelParamName);
             EmitCollectionValidators(sb, collectionProperties, modelParamName);
         }
         else
         {
-            EmitNestedPathStop(sb, classSymbol, byProperty, nestedProperties, collectionProperties, modelParamName);
+            EmitNestedPathStop(sb, classSymbol, byProperty, nestedProperties, collectionProperties, modelParamName, ctx);
         }
 
         // [CustomValidation] methods always run last.
@@ -179,7 +180,8 @@ internal static class RuleEmitter
         List<(IPropertySymbol Property, List<AttributeData> Rules)> byProperty,
         List<IPropertySymbol> nestedProperties,
         List<(IPropertySymbol Property, INamedTypeSymbol ElementType)> collectionProperties,
-        string modelParamName)
+        string modelParamName,
+        SourceProductionContext? ctx)
     {
         int groupIdx = 0;
         int collCi = 0;
@@ -200,7 +202,7 @@ internal static class RuleEmitter
             sb.AppendLine($"        int _b{groupIdx} = _buf.Count;");
 
             if (directProp is not null && directRules is not null)
-                EmitPropertyRulesForProp(sb, directProp, directRules, modelParamName);
+                EmitPropertyRulesForProp(sb, directProp, directRules, modelParamName, ctx);
 
             if (nestedProp is not null)
                 EmitNestedValidatorForProp(sb, nestedProp, modelParamName);
@@ -263,12 +265,13 @@ internal static class RuleEmitter
     private static void EmitPropertyRulesWithAdd(
         StringBuilder sb,
         List<(IPropertySymbol Property, List<AttributeData> Rules)> byProperty,
-        string modelParamName)
+        string modelParamName,
+        SourceProductionContext? ctx)
     {
         for (int pi = 0; pi < byProperty.Count; pi++)
         {
             var (prop, rules) = byProperty[pi];
-            EmitPropertyRulesForProp(sb, prop, rules, modelParamName);
+            EmitPropertyRulesForProp(sb, prop, rules, modelParamName, ctx);
         }
     }
 
@@ -276,12 +279,15 @@ internal static class RuleEmitter
         StringBuilder sb,
         IPropertySymbol prop,
         List<AttributeData> rules,
-        string modelParamName)
+        string modelParamName,
+        SourceProductionContext? ctx)
     {
         var propName = prop.Name;
         var displayName = GetDisplayName(prop) ?? propName;
         var propAccess = BuildPropertyAccess(modelParamName, prop);
         var stopMode = HasStopOnFirstFailure(prop);
+
+        ReportZV0016IfApplicable(ctx, prop, rules);
 
         for (int i = 0; i < rules.Count; i++)
         {
@@ -377,7 +383,8 @@ internal static class RuleEmitter
         List<(IPropertySymbol Property, List<AttributeData> Rules)> byProperty,
         int totalDirectRules,
         string modelParamName,
-        bool validatorStop)
+        bool validatorStop,
+        SourceProductionContext? ctx)
     {
         // Lazy allocation: buffer is only created on the first failure.
         // On the valid path (0 failures) no heap allocation occurs.
@@ -390,7 +397,7 @@ internal static class RuleEmitter
             if (validatorStop)
                 sb.AppendLine($"        int _b{pi} = _count;");
 
-            EmitFlatPathPropertyRules(sb, byProperty[pi].Property, byProperty[pi].Rules, totalDirectRules, modelParamName);
+            EmitFlatPathPropertyRules(sb, byProperty[pi].Property, byProperty[pi].Rules, totalDirectRules, modelParamName, ctx);
 
             if (validatorStop)
                 EmitFlatPathStopOnFirstFailureReturn(sb, pi);
@@ -410,12 +417,15 @@ internal static class RuleEmitter
         IPropertySymbol prop,
         List<AttributeData> rules,
         int totalDirectRules,
-        string modelParamName)
+        string modelParamName,
+        SourceProductionContext? ctx)
     {
         var propName = prop.Name;
         var displayName = GetDisplayName(prop) ?? propName;
         var propAccess = BuildPropertyAccess(modelParamName, prop);
         var stopMode = HasStopOnFirstFailure(prop);
+
+        ReportZV0016IfApplicable(ctx, prop, rules);
 
         for (int i = 0; i < rules.Count; i++)
         {
@@ -953,10 +963,10 @@ internal static class RuleEmitter
     /// Returns the Validate method body as a string (multi-statement block WITHOUT outer braces),
     /// using <paramref name="modelParamName"/> as the instance variable.
     /// </summary>
-    internal static string EmitValidateBodyAsString(INamedTypeSymbol classSymbol, string modelParamName)
+    internal static string EmitValidateBodyAsString(INamedTypeSymbol classSymbol, string modelParamName, SourceProductionContext? ctx = null)
     {
         var sb = new System.Text.StringBuilder();
-        EmitValidateBody(sb, classSymbol, modelParamName);
+        EmitValidateBody(sb, classSymbol, modelParamName, ctx);
         return sb.ToString();
     }
 
@@ -1022,5 +1032,40 @@ internal static class RuleEmitter
         var raw = $"{modelParamName}.{prop.Name}";
         var unwrapMember = GetValueObjectUnwrapMember(prop.Type);
         return unwrapMember is not null ? $"{raw}.{unwrapMember}" : raw;
+    }
+
+    private static readonly DiagnosticDescriptor ZV0016 = new DiagnosticDescriptor(
+        id: "ZV0016",
+        title: "Value-object with multiple properties can't be auto-unwrapped",
+        messageFormat:
+            "Property '{0}' of type '{1}' carries a built-in validator but '{1}' is a multi-property value-object ({2} properties). " +
+            "Auto-unwrap requires exactly one underlying property. " +
+            "Either declare the validator on a single-property value-object, or use [Must] / [CustomValidation] with a custom predicate.",
+        category: "ZeroAlloc.Validation",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    /// <summary>
+    /// Fires ZV0016 when a property has built-in validation rules and its type is a
+    /// multi-property <c>[ValueObject]</c> (i.e. has the marker attribute but no
+    /// single property to auto-unwrap through). Single-property value-objects are
+    /// handled by <see cref="BuildPropertyAccess"/>; primitives/class types are
+    /// emitted as-is.
+    /// </summary>
+    private static void ReportZV0016IfApplicable(SourceProductionContext? ctx, IPropertySymbol prop, List<AttributeData> rules)
+    {
+        if (ctx is null) return;
+        if (rules.Count == 0) return;
+        if (!HasValueObjectAttribute(prop.Type)) return;
+        if (GetValueObjectUnwrapMember(prop.Type) is not null) return;
+
+        var propCount = ((INamedTypeSymbol)prop.Type).GetMembers()
+            .OfType<IPropertySymbol>()
+            .Count(p => !p.IsStatic && p.DeclaredAccessibility == Accessibility.Public);
+
+        ctx.Value.ReportDiagnostic(Diagnostic.Create(
+            ZV0016,
+            prop.Locations.FirstOrDefault() ?? Location.None,
+            prop.Name, prop.Type.Name, propCount));
     }
 }

--- a/src/ZeroAlloc.Validation.Generator/ValidatorGenerator.cs
+++ b/src/ZeroAlloc.Validation.Generator/ValidatorGenerator.cs
@@ -129,7 +129,7 @@ public sealed class ValidatorGenerator : IIncrementalGenerator
         var nestedFields = RuleEmitter.CollectNestedValidatorFields(classSymbol);
         EmitFieldsAndConstructor(sb, validatorName, nestedFields);
 
-        EmitValidateMethod(sb, classSymbol, modelName, syncBehaviors);
+        EmitValidateMethod(ctx, sb, classSymbol, modelName, syncBehaviors);
         EmitValidateAsyncOverride(sb, classSymbol, modelName, asyncBehaviors);
 
         sb.AppendLine("}");
@@ -138,6 +138,7 @@ public sealed class ValidatorGenerator : IIncrementalGenerator
     }
 
     private static void EmitValidateMethod(
+        SourceProductionContext ctx,
         System.Text.StringBuilder sb,
         INamedTypeSymbol classSymbol,
         string modelName,
@@ -147,11 +148,12 @@ public sealed class ValidatorGenerator : IIncrementalGenerator
         sb.AppendLine("    {");
         if (syncBehaviors.Count == 0)
         {
-            RuleEmitter.EmitValidateBody(sb, classSymbol);
+            RuleEmitter.EmitValidateBody(sb, classSymbol, "instance", ctx);
         }
         else
         {
             var fullyQualifiedModel = classSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+            var capturedCtx = ctx;
             var syncShape = new global::ZeroAlloc.Pipeline.Generators.PipelineShape
             {
                 TypeArguments           = new[] { fullyQualifiedModel },
@@ -161,7 +163,7 @@ public sealed class ValidatorGenerator : IIncrementalGenerator
                 {
                     var paramName = depth == 0 ? "instance" : $"r{depth}";
                     return "{\n"
-                        + RuleEmitter.EmitValidateBodyAsString(classSymbol, paramName)
+                        + RuleEmitter.EmitValidateBodyAsString(classSymbol, paramName, capturedCtx)
                         + "        }";
                 }
             };

--- a/tests/ZeroAlloc.Validation.Tests/Generator/ValueObjectPropertyDiagnosticTests.cs
+++ b/tests/ZeroAlloc.Validation.Tests/Generator/ValueObjectPropertyDiagnosticTests.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+using ZeroAlloc.Validation;
+using ZeroAlloc.Validation.Generator;
+
+namespace ZeroAlloc.Validation.Tests.Generator;
+
+public class ValueObjectPropertyDiagnosticTests
+{
+    [Fact]
+    public void ValueObject_TypedId_Property_Rewrites_To_Unwrap_Member()
+    {
+        var source = """
+            using ZeroAlloc.Validation;
+            using ZeroAlloc.ValueObjects;
+            namespace TestModels;
+
+            [ValueObject]
+            public readonly partial struct CustomerId
+            {
+                public int Value { get; }
+                public CustomerId(int value) => Value = value;
+            }
+
+            [Validate]
+            public readonly record struct PlaceOrderCommand(
+                [property: GreaterThan(0)] CustomerId CustomerId);
+            """;
+
+        var result = RunGenerator(source);
+
+        Assert.Empty(result.Diagnostics);
+        var validatorSource = GetGeneratedSource(result, "PlaceOrderCommandValidator.g.cs");
+        Assert.Contains("instance.CustomerId.Value", validatorSource, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Primitive_Property_Still_Emits_Raw_Access()
+    {
+        var source = """
+            using ZeroAlloc.Validation;
+            namespace TestModels;
+
+            [Validate]
+            public readonly record struct PlaceOrderCommand(
+                [property: GreaterThan(0)] int CustomerId);
+            """;
+
+        var result = RunGenerator(source);
+
+        Assert.Empty(result.Diagnostics);
+        var validatorSource = GetGeneratedSource(result, "PlaceOrderCommandValidator.g.cs");
+        Assert.Contains("instance.CustomerId", validatorSource, StringComparison.Ordinal);
+        Assert.DoesNotContain("instance.CustomerId.Value", validatorSource, StringComparison.Ordinal);
+    }
+
+    private static string GetGeneratedSource(GeneratorDriverRunResult result, string filenameSuffix) =>
+        result.GeneratedTrees
+            .First(t => t.FilePath.EndsWith(filenameSuffix, StringComparison.Ordinal))
+            .ToString();
+
+    private static GeneratorDriverRunResult RunGenerator(string source)
+    {
+        var valueObjectStub = """
+            namespace ZeroAlloc.ValueObjects
+            {
+                [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Struct)]
+                public sealed class ValueObjectAttribute : System.Attribute { }
+            }
+            """;
+
+        var compilation = CSharpCompilation.Create(
+            "TestAssembly",
+            [CSharpSyntaxTree.ParseText(source), CSharpSyntaxTree.ParseText(valueObjectStub)],
+            [
+                MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+                MetadataReference.CreateFromFile(typeof(ValidateAttribute).Assembly.Location),
+            ],
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        var generator = new ValidatorGenerator();
+        var driver = CSharpGeneratorDriver.Create(generator).RunGenerators(compilation);
+        return driver.GetRunResult();
+    }
+}

--- a/tests/ZeroAlloc.Validation.Tests/Generator/ValueObjectPropertyDiagnosticTests.cs
+++ b/tests/ZeroAlloc.Validation.Tests/Generator/ValueObjectPropertyDiagnosticTests.cs
@@ -57,6 +57,61 @@ public class ValueObjectPropertyDiagnosticTests
         Assert.DoesNotContain("instance.CustomerId.Value", validatorSource, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void MultiProperty_ValueObject_With_BuiltIn_Validator_Fires_ZV0016()
+    {
+        var source = """
+            using ZeroAlloc.Validation;
+            using ZeroAlloc.ValueObjects;
+            namespace TestModels;
+
+            [ValueObject]
+            public readonly partial struct Money
+            {
+                public decimal Amount { get; }
+                public string Currency { get; }
+                public Money(decimal amount, string currency)
+                {
+                    Amount = amount;
+                    Currency = currency;
+                }
+            }
+
+            [Validate]
+            public readonly record struct PriceCommand(
+                [property: GreaterThan(0)] Money Total);
+            """;
+
+        var result = RunGenerator(source);
+
+        Assert.Contains(result.Diagnostics, d => string.Equals(d.Id, "ZV0016", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void SingleProperty_ValueObject_Does_Not_Fire_ZV0016()
+    {
+        var source = """
+            using ZeroAlloc.Validation;
+            using ZeroAlloc.ValueObjects;
+            namespace TestModels;
+
+            [ValueObject]
+            public readonly partial struct CustomerId
+            {
+                public int Value { get; }
+                public CustomerId(int value) => Value = value;
+            }
+
+            [Validate]
+            public readonly record struct PlaceOrderCommand(
+                [property: GreaterThan(0)] CustomerId CustomerId);
+            """;
+
+        var result = RunGenerator(source);
+
+        Assert.DoesNotContain(result.Diagnostics, d => string.Equals(d.Id, "ZV0016", StringComparison.Ordinal));
+    }
+
     private static string GetGeneratedSource(GeneratorDriverRunResult result, string filenameSuffix) =>
         result.GeneratedTrees
             .First(t => t.FilePath.EndsWith(filenameSuffix, StringComparison.Ordinal))

--- a/tests/ZeroAlloc.Validation.Tests/Generator/ValueObjectPropertyDiagnosticTests.cs
+++ b/tests/ZeroAlloc.Validation.Tests/Generator/ValueObjectPropertyDiagnosticTests.cs
@@ -112,6 +112,40 @@ public class ValueObjectPropertyDiagnosticTests
         Assert.DoesNotContain(result.Diagnostics, d => string.Equals(d.Id, "ZV0016", StringComparison.Ordinal));
     }
 
+    [Fact]
+    public void Must_Predicate_On_ValueObject_Property_Passes_Wrapper_Not_Unwrap()
+    {
+        var source = """
+            using ZeroAlloc.Validation;
+            using ZeroAlloc.ValueObjects;
+            namespace TestModels;
+
+            [ValueObject]
+            public readonly partial struct CustomerId
+            {
+                public int Value { get; }
+                public CustomerId(int value) => Value = value;
+            }
+
+            [Validate]
+            public partial class PlaceOrderCommand
+            {
+                [Must(nameof(IsKnown))]
+                public CustomerId CustomerId { get; set; }
+
+                public bool IsKnown(CustomerId id) => id.Value > 0;
+            }
+            """;
+
+        var result = RunGenerator(source);
+
+        Assert.Empty(result.Diagnostics);
+        var validatorSource = GetGeneratedSource(result, "PlaceOrderCommandValidator.g.cs");
+        // The Must predicate receives the wrapper, NOT instance.CustomerId.Value.
+        Assert.Contains("instance.CustomerId", validatorSource, StringComparison.Ordinal);
+        Assert.DoesNotContain("instance.CustomerId.Value", validatorSource, StringComparison.Ordinal);
+    }
+
     private static string GetGeneratedSource(GeneratorDriverRunResult result, string filenameSuffix) =>
         result.GeneratedTrees
             .First(t => t.FilePath.EndsWith(filenameSuffix, StringComparison.Ordinal))
@@ -127,12 +161,15 @@ public class ValueObjectPropertyDiagnosticTests
             }
             """;
 
+        var systemRuntime = System.Runtime.InteropServices.RuntimeEnvironment.GetRuntimeDirectory();
         var compilation = CSharpCompilation.Create(
             "TestAssembly",
             [CSharpSyntaxTree.ParseText(source), CSharpSyntaxTree.ParseText(valueObjectStub)],
             [
                 MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
                 MetadataReference.CreateFromFile(typeof(ValidateAttribute).Assembly.Location),
+                MetadataReference.CreateFromFile(System.IO.Path.Combine(systemRuntime, "System.Runtime.dll")),
+                MetadataReference.CreateFromFile(typeof(System.Collections.Generic.List<>).Assembly.Location),
             ],
             new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
 

--- a/tests/ZeroAlloc.Validation.Tests/Integration/ValueObjectPropertyValidationTests.cs
+++ b/tests/ZeroAlloc.Validation.Tests/Integration/ValueObjectPropertyValidationTests.cs
@@ -1,0 +1,37 @@
+#pragma warning disable MA0048 // multiple types intentionally co-located
+
+using Xunit;
+using ZeroAlloc.Validation;
+
+// Local ValueObjectAttribute matching the ZA.ValueObjects FQN — no runtime ref needed.
+namespace ZeroAlloc.ValueObjects
+{
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct)]
+    public sealed class ValueObjectAttribute : System.Attribute { }
+}
+
+namespace ZeroAlloc.Validation.Tests.Integration
+{
+    public class ValueObjectPropertyValidationTests
+    {
+        [Fact]
+        public void TypedId_GreaterThan_HappyPath_ReportsValid()
+        {
+            var validator = new PlaceOrderTypedCommandValidator();
+            var result = validator.Validate(new PlaceOrderTypedCommand(new CustomerId(42)));
+            Assert.True(result.IsValid);
+            Assert.True(result.Failures.IsEmpty);
+        }
+    }
+
+    [global::ZeroAlloc.ValueObjects.ValueObject]
+    public readonly partial struct CustomerId
+    {
+        public int Value { get; }
+        public CustomerId(int value) => Value = value;
+    }
+
+    [Validate]
+    public readonly record struct PlaceOrderTypedCommand(
+        [property: GreaterThan(0)] CustomerId CustomerId);
+}

--- a/tests/ZeroAlloc.Validation.Tests/Integration/ValueObjectPropertyValidationTests.cs
+++ b/tests/ZeroAlloc.Validation.Tests/Integration/ValueObjectPropertyValidationTests.cs
@@ -22,6 +22,37 @@ namespace ZeroAlloc.Validation.Tests.Integration
             Assert.True(result.IsValid);
             Assert.True(result.Failures.IsEmpty);
         }
+
+        [Fact]
+        public void TypedId_GreaterThan_SadPath_ReportsFailureOnTypedIdProperty()
+        {
+            var validator = new PlaceOrderTypedCommandValidator();
+            var result = validator.Validate(new PlaceOrderTypedCommand(new CustomerId(0)));
+            Assert.False(result.IsValid);
+            Assert.Equal(1, result.Failures.Length);
+            Assert.Equal(nameof(PlaceOrderTypedCommand.CustomerId), result.Failures[0].PropertyName);
+        }
+
+        [Theory]
+        [InlineData("alice", true)]
+        [InlineData("", false)]
+        public void StringValueObject_NotEmpty_Behaves(string raw, bool expectedValid)
+        {
+            var validator = new CreateUserCommandValidator();
+            var result = validator.Validate(new CreateUserCommand(new Username(raw)));
+            Assert.Equal(expectedValid, result.IsValid);
+        }
+
+        [Theory]
+        [InlineData(50, true)]
+        [InlineData(0, false)]
+        [InlineData(101, false)]
+        public void TypedId_InclusiveBetween_Behaves(int raw, bool expectedValid)
+        {
+            var validator = new GetPageCommandValidator();
+            var result = validator.Validate(new GetPageCommand(new PageNumber(raw)));
+            Assert.Equal(expectedValid, result.IsValid);
+        }
     }
 
     [global::ZeroAlloc.ValueObjects.ValueObject]
@@ -34,4 +65,26 @@ namespace ZeroAlloc.Validation.Tests.Integration
     [Validate]
     public readonly record struct PlaceOrderTypedCommand(
         [property: GreaterThan(0)] CustomerId CustomerId);
+
+    [global::ZeroAlloc.ValueObjects.ValueObject]
+    public readonly partial struct Username
+    {
+        public string Value { get; }
+        public Username(string value) => Value = value;
+    }
+
+    [Validate]
+    public readonly record struct CreateUserCommand(
+        [property: NotEmpty] Username Name);
+
+    [global::ZeroAlloc.ValueObjects.ValueObject]
+    public readonly partial struct PageNumber
+    {
+        public int Value { get; }
+        public PageNumber(int value) => Value = value;
+    }
+
+    [Validate]
+    public readonly record struct GetPageCommand(
+        [property: InclusiveBetween(1, 100)] PageNumber Page);
 }


### PR DESCRIPTION
## Summary

Closes backlog B1. Built-in operand-taking validators (``[GreaterThan]``, ``[NotEmpty]``, ``[InclusiveBetween]``, ``[Matches]``, ``[Length]``, …) now unwrap properties whose type is a single-property ``[ZeroAlloc.ValueObjects.ValueObject]``. The validator emits its comparison/regex/length code against ``instance.Prop.Value`` instead of ``instance.Prop``, so this becomes legal:

```csharp
[Validate]
public readonly record struct PlaceOrderCommand(
    [property: GreaterThan(0)] CustomerId CustomerId,
    [property: NotEmpty] Username Name);
```

Previously the only workaround was to drop value-objects from request types and re-wrap manually in the handler.

Surfaced 2026-05-26 building the ``za-vertical-slice`` template. The template's six request types currently carry raw ``int`` / ``decimal`` properties for exactly this reason; once 1.5.0 propagates, a follow-up template PR can adopt typed properties.

## What changed

- Three private helpers in ``RuleEmitter.cs``:
  - ``ValueObjectAttributeFqn`` const — the FQN of ``ZeroAlloc.ValueObjects.ValueObjectAttribute``.
  - ``GetValueObjectUnwrapMember(ITypeSymbol)`` — returns the underlying property name when the type is a single-property ``[ValueObject]``; ``null`` otherwise.
  - ``HasValueObjectAttribute(ITypeSymbol)`` — true when the type carries ``[ValueObject]`` regardless of property count. Used by the ZV0016 emission.
  - ``BuildPropertyAccess(modelParamName, prop)`` — central access-expression builder. Returns ``instance.Prop.Value`` for value-objects, ``instance.Prop`` otherwise.
- Three rewrite sites consolidated through ``BuildPropertyAccess``:
  - ``EmitPropertyRulesForProp`` (lazy-allocation path)
  - ``EmitFlatPathPropertyRules`` (zero-failure-allocation path)
  - ``BuildPropertyValueExpr`` (the ``{value}`` message-placeholder interpolator)
- Predicate carve-out: ``BuildCondition`` gains a ``rawPropAccess`` parameter. The ``MustFqn`` branch routes to ``rawPropAccess`` (preserves the wrapper for user-defined predicate methods). ``[CustomValidation]`` and ``[ValidateWith]`` don't route through ``BuildCondition`` at all (class-level / nested-validator paths respectively) and are unaffected.
- New ``ZV0016`` Warning when a property carries a built-in validator and the type is a multi-property ``[ValueObject]`` (e.g. ``Money { Amount, Currency }``). ``SourceProductionContext`` threaded through the per-property emit chain as nullable so only the sync ``Validate`` emission path reports the diagnostic (async ``ValidateAsync`` would double-fire on the same property otherwise).
- 4 integration tests covering: TypedId happy + sad paths, string value-object ``[NotEmpty]`` ``[Theory]``, range validator on a TypedId.
- 5 generator-snapshot tests covering: value-object rewrite present, primitive rewrite absent (regression net), multi-property ZV0016 fires, single-property doesn't fire, ``[Must]`` predicate carve-out preserves the wrapper.

## Decisions ([design doc](docs/plans/2026-05-27-value-object-property-validators-design.md))

- **FQN-based attribute detection** — ZA.Validation never references ZA.ValueObjects at runtime; only matches ``ZeroAlloc.ValueObjects.ValueObjectAttribute`` by metadata name. Adopters who don't use ZA.ValueObjects pay nothing.
- **Single-property requirement.** Multi-property value-objects fall through with ``ZV0016`` — the user picks either a single-property shape or a custom predicate.
- **Predicate validator carve-out** turned out to NOT be automatic. The B1 rewrite leaked into ``[Must]``'s emission via ``BuildCondition:681``; Phase 5's regression test caught it, fixed via the explicit ``rawPropAccess`` parameter routing.
- **Nullable ``SourceProductionContext?``** threading for ZV0016 — sync path passes the real ctx, async path passes ``null`` so the diagnostic fires exactly once per offending property even when both ``Validate`` and ``ValidateAsync`` emit.

## SemVer

``1.4.1`` → ``1.5.0`` (additive minor — new shapes compile that previously didn't; existing class/primitive consumers see byte-identical generator output).

## Test plan

- [x] ``dotnet test -c Release`` — all green locally on net8/net9/net10 (984 across all suites + TFMs)
- [ ] CI — green on this PR
- [ ] Follow-up after 1.5.0 propagates: ``ZeroAlloc.Templates`` migrates ``za-vertical-slice``'s 6 request types from raw ``int`` / ``decimal`` properties to typed ``CustomerId`` / ``OrderId`` / etc., closing the original friction loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)