### PR TITLE
chore(aot-smoke): cover ValidateWith, nested, cross-property Must paths

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -21,23 +21,17 @@ Candidate enhancements identified during real-world usage. Each item is independ
 
 ---
 
-## B4 — Extend aot-smoke to cover `[ValidateWith]`, nested chains, cross-property `[Must]` predicates
+## ~~B4 — Extend aot-smoke to cover `[ValidateWith]`, nested chains, cross-property `[Must]` predicates~~ — ✅ shipped 2026-05-28
 
-**What.** The existing `aot-smoke` project exercises `[Validate]` happy-path and fail-path validators on simple types. It does NOT touch three of the more reflective-feeling code paths the generator emits: `[ValidateWith]` with a custom validator class, nested property-validation chains (a `[Validate]` type containing a `[Validate]` collection / property), and cross-property rules (`[Must]` predicates that compare two properties). Under Native AOT + the trimmer, any of these could regress silently.
+**Shipped:** Three new fixtures in `samples/ZeroAlloc.Validation.AotSmoke/` (`Letter.cs` + `Postcode.cs` + `PostcodeValidator.cs` for `[ValidateWith]`; `Order.cs` + `OrderItem.cs` for nested `IReadOnlyList<[Validate]>`; `DateRange.cs` for cross-property `[Must]`) plus matching assertion blocks in `Program.cs`. Asserts both invalid + valid input, both failure count + PropertyName patterns — including the load-bearing `Items[1]` indexed PropertyName for the nested-collection case (confirmed against the generator's documented `{parent}[{idx}].{child}` PropertyName format).
 
-**Why.** Surfaced 2026-05-27 during the org-wide AOT-smoke coverage survey done after [ZeroAlloc.Serialisation](https://github.com/ZeroAlloc-Net/ZeroAlloc.Serialisation) shipped 2.3.1 + 2.3.2 reactively. ZA.Serialisation's smoke covered only the V0 path; V1 `[ValueObject]` paths were untouched — two patches shipped reactively. Same "smoke exists but partial" risk applies here.
+**Findings worth flagging** (durable record):
 
-**Sketch.** Extend `samples/ZeroAlloc.Validation.AotSmoke/Program.cs` with three fixtures + assertions:
+- **Generator emits DI-ctor injection for nested `[Validate]` types AND `[ValidateWith]` references.** `new OrderValidator(new OrderItemValidator())` not `new OrderValidator()`. `[Must]` is a predicate (not a sub-validator) and does NOT trigger ctor injection.
+- **`EPS06` analyzer false-positives on `ref readonly var f in result.Failures`** despite `ValidationFailure` being a `readonly struct`. Same `#pragma warning disable EPS06` workaround that `src/ZeroAlloc.Validation/Testing/ValidationAssert.cs` already uses.
+- **`MA0048` enforces one-type-per-file** — `Letter`/`Postcode`/`PostcodeValidator` ended up in three separate files, `Order`/`OrderItem` in two.
 
-- A `[Validate]` type with a property carrying `[ValidateWith(typeof(MyCustomValidator))]`; assert the custom validator fires on bad input and is skipped on good input.
-- A `[Validate]` `OrderCommand` with an `IReadOnlyList<[Validate] OrderItem> Items` property; assert per-item validation fires and indices match.
-- A `[Validate]` type with a `[Must]` cross-property predicate (e.g. `EndDate > StartDate`); assert the predicate fires on bad input.
-
-The existing happy/fail-path tests stay; this is purely additive.
-
-**Tradeoff / risks.** Same shape as the existing smoke — no new CI infrastructure. Risk: nested-collection validation is sensitive to indentation/scoping in the generated code; the regression net is a runtime invariant, not a snapshot, so it tolerates surface refactoring.
-
-**Graduation signal.** Pair with the next ZA.Validation generator change. Or proactive: ship as a 1.5.x chore commit.
+**Design + plan:** [`docs/plans/2026-05-28-aot-smoke-validation-paths-design.md`](plans/2026-05-28-aot-smoke-validation-paths-design.md) + [`docs/plans/2026-05-28-aot-smoke-validation-paths.md`](plans/2026-05-28-aot-smoke-validation-paths.md).
 
 ---
 

--- a/docs/plans/2026-05-28-aot-smoke-validation-paths-design.md
+++ b/docs/plans/2026-05-28-aot-smoke-validation-paths-design.md
@@ -1,0 +1,187 @@
+# aot-smoke Coverage Extension — Design
+
+**Date:** 2026-05-28
+**Scope:** ZeroAlloc.Validation aot-smoke project (`samples/ZeroAlloc.Validation.AotSmoke/`) — extend coverage from the single `[Validate] Address` with `[NotEmpty]` baseline to also exercise three previously-uncovered emission paths: `[ValidateWith(typeof(...))]`, nested `IReadOnlyList<[Validate] T>`, and cross-property `[Must(nameof(Method))]` predicates. Closes backlog item B4.
+
+## Background
+
+The existing aot-smoke project covers exactly one path: a `[Validate]` class with two `[NotEmpty]` properties. It asserts that empty input produces 2 failures and populated input produces 0. That validates the simplest generator-output shape.
+
+It does NOT touch three more-interesting paths the generator emits:
+
+- `[ValidateWith(typeof(MyCustomValidator))]` — points a property at an external `ValidatorFor<T>` subclass written by the user. The generator emits a call into that validator but does not validate its existence at compile time beyond a type check.
+- Nested `IReadOnlyList<[Validate] T>` — a `[Validate]` type containing a list of items that are themselves `[Validate]`-decorated. The generator emits a foreach loop with per-item validation and indexed PropertyName reporting (`Items[N].Field`).
+- Cross-property `[Must(nameof(Method))]` — a property-level predicate that runs an instance method on the model. Because the method is an instance method (`this.OtherProperty` is reachable), `[Must]` is the canonical cross-property check.
+
+Surfaced 2026-05-28 during the org-wide aot-smoke coverage survey after [ZeroAlloc.Serialisation](https://github.com/ZeroAlloc-Net/ZeroAlloc.Serialisation) shipped 2.3.1 + 2.3.2 reactively because its existing smoke only covered the V0 path and left the V1 `[ValueObject]` paths un-validated. Same "smoke exists but partial" pattern applies here — the next downstream consumer to use any of these three Validation paths under Native AOT will discover the regression instead of CI doing so.
+
+## Goal
+
+A regression in the generator-emitted code for any of the three paths fails the aot-smoke job locally. The existing `Address` happy/fail path stays green; the three new fixtures + assertions are strictly additive.
+
+## Decisions
+
+### D-1: three independent fixtures, one per uncovered path
+
+`Letter` (ValidateWith), `Order` (nested), `DateRange` (Must). Each in its own file (`Letter.cs`, `Order.cs`, `DateRange.cs`). Smoke assertions are organised by fixture so a failure pinpoints which feature broke.
+
+**Considered and rejected:**
+
+- **Single combined fixture** (`BigOrder` with all three patterns in one class). Smaller LOC but assertion failures become ambiguous — a "failure count mismatch" doesn't say which feature regressed.
+
+### D-2: tight assertions — count AND PropertyName
+
+Each invalid-input assertion checks failure count AND that PropertyName matches the expected pattern. The nested fixture especially asserts `Items[1]` appears in the PropertyName, which is the load-bearing invariant that distinguishes "index reporting works" from "per-item validation runs but loses the index".
+
+**Considered and rejected:**
+
+- **Count-only assertions** (match existing `Address` style). Looser, more tolerant of PropertyName-format changes, but leaves coverage holes — a regression that drops the index from `Items[1].Field` to `Items.Field` would still pass.
+
+### D-3: no in-process integration test additions
+
+The existing `tests/ZeroAlloc.Validation.Tests/` suite already exercises these three paths in JIT. The smoke project is the AOT-specific regression net. Adding a parallel in-process test would be redundant.
+
+### D-4: no library API changes, no NuGet release
+
+This is purely CI hygiene. No `src/` files touched. The PR ships smoke project changes + a backlog strikethrough. release-please sees `chore:` and skips the release manifest — no NuGet bump. The win is "the next migration in ZA.Validation territory can't silently regress these three paths."
+
+### D-5: strikethrough form for B4 entry
+
+The B4 entry on `main` (added by [PR #49](https://github.com/ZeroAlloc-Net/ZeroAlloc.Validation/pull/49)) gets struck through to its shipped form in the same PR that ships the work. Mirrors the V1.5/V1.6 strikethrough convention from ZA.Serialisation.
+
+## Design
+
+### Fixture 1 — `[ValidateWith]` pointing at an external validator
+
+**File (NEW):** `samples/ZeroAlloc.Validation.AotSmoke/Letter.cs`
+
+```csharp
+using ZeroAlloc.Validation;
+
+namespace ZeroAlloc.Validation.AotSmoke;
+
+// External (non-[Validate]) type — the generator can't emit a validator
+// for it directly. [ValidateWith] points at a hand-written ValidatorFor<T>.
+public sealed class Postcode
+{
+    public string Value { get; set; } = "";
+}
+
+public sealed class PostcodeValidator : ValidatorFor<Postcode>
+{
+    public override ValidationResult Validate(Postcode value, ...)
+    {
+        // Fail when empty; pass otherwise.
+        // Concrete signature confirmed in implementation phase against the
+        // ValidatorFor<T> base — likely uses a ValidationResult builder
+        // or a Failures list parameter.
+    }
+}
+
+[Validate]
+public sealed class Letter
+{
+    [ValidateWith(typeof(PostcodeValidator))]
+    public Postcode Postcode { get; set; } = new();
+}
+```
+
+The exact `ValidatorFor<T>.Validate` override signature is verified during the implementation Phase 1 (read the base class). Likely `ValidationResult Validate(T value)` or `void Validate(T value, ValidationContext context)`.
+
+**Program.cs assertions:**
+
+- Invalid: `new Letter { Postcode = new() }` (empty Postcode.Value) → 1 failure
+- Valid: `new Letter { Postcode = new() { Value = "1234 AB" } }` → 0 failures
+
+### Fixture 2 — Nested `IReadOnlyList<[Validate] T>` with index reporting
+
+**File (NEW):** `samples/ZeroAlloc.Validation.AotSmoke/Order.cs`
+
+```csharp
+using System.Collections.Generic;
+using ZeroAlloc.Validation;
+
+namespace ZeroAlloc.Validation.AotSmoke;
+
+[Validate]
+public sealed class OrderItem
+{
+    [NotEmpty] public string Sku { get; set; } = "";
+}
+
+[Validate]
+public sealed class Order
+{
+    [NotEmpty] public string CustomerName { get; set; } = "";
+    public IReadOnlyList<OrderItem> Items { get; set; } = System.Array.Empty<OrderItem>();
+}
+```
+
+**Program.cs assertions:**
+
+- Invalid: Order with valid CustomerName + Items list `[validItem, badItem]` (where badItem has empty Sku) → 1 failure, PropertyName contains `Items[1]`
+- Valid: Order with valid CustomerName + Items list `[validItem]` → 0 failures
+- Optional: empty Items list `[]` → 0 failures (or 1 if the generator validates non-emptiness — verify; the design accepts whatever the generator's documented semantics are)
+
+### Fixture 3 — Cross-property `[Must]`
+
+**File (NEW):** `samples/ZeroAlloc.Validation.AotSmoke/DateRange.cs`
+
+```csharp
+using System;
+using ZeroAlloc.Validation;
+
+namespace ZeroAlloc.Validation.AotSmoke;
+
+[Validate]
+public sealed class DateRange
+{
+    public DateTime StartDate { get; set; }
+
+    [Must(nameof(IsAfterStart))]
+    public DateTime EndDate { get; set; }
+
+    // Instance method — sees `this.StartDate` for the cross-property check.
+    // Signature per docs/attributes.md: bool MethodName(TPropType value).
+    public bool IsAfterStart(DateTime endValue) => endValue > StartDate;
+}
+```
+
+**Program.cs assertions:**
+
+- Invalid: `new DateRange { StartDate = T+1, EndDate = T }` → 1 failure, PropertyName is `EndDate`
+- Valid: `new DateRange { StartDate = T, EndDate = T+1 }` → 0 failures
+
+### Program.cs structure
+
+After the existing `Address` happy/fail block (lines 1-33 of current file), append three additional blocks following the same pattern: validator construction → invalid input → assertion → valid input → assertion. Each block exits non-zero on failure.
+
+Total Program.cs growth: ~70 LOC (3 blocks × ~20-25 LOC each).
+
+### Backlog update
+
+Find the existing B4 entry in `docs/backlog.md` and replace its content with a struck-through shipped marker:
+
+```markdown
+## ~~B4 — Extend aot-smoke to cover `[ValidateWith]`, nested chains, cross-property `[Must]` predicates~~ — ✅ shipped 2026-05-28
+
+**Shipped:** Three new fixtures in `samples/ZeroAlloc.Validation.AotSmoke/` (`Letter.cs`, `Order.cs`, `DateRange.cs`) plus matching assertion blocks in `Program.cs` exercise the three previously-uncovered generator-emission paths. Asserts both invalid + valid input, both failure count + PropertyName patterns — including the load-bearing `Items[1]` indexed PropertyName for the nested-collection case.
+
+**Design + plan:** [`docs/plans/2026-05-28-aot-smoke-validation-paths-design.md`](plans/2026-05-28-aot-smoke-validation-paths-design.md) + [`docs/plans/2026-05-28-aot-smoke-validation-paths.md`](plans/2026-05-28-aot-smoke-validation-paths.md).
+```
+
+### Files touched
+
+- **NEW:** `samples/ZeroAlloc.Validation.AotSmoke/Letter.cs`
+- **NEW:** `samples/ZeroAlloc.Validation.AotSmoke/Order.cs`
+- **NEW:** `samples/ZeroAlloc.Validation.AotSmoke/DateRange.cs`
+- **MOD:** `samples/ZeroAlloc.Validation.AotSmoke/Program.cs` — three additional assertion blocks
+- **MOD:** `docs/backlog.md` — strike B4 shipped
+
+Total commit footprint: ~110 LOC.
+
+## Out of scope
+
+- **Empty-list semantics test** — if the generator's nested-validation produces 0 failures for an empty list (the natural default), the smoke happens to validate that as a side-effect of the "valid Order" assertion. Not a separately-asserted invariant.
+- **Combinations of features** — a fixture exercising e.g. ValidateWith + Must + nesting simultaneously. YAGNI; each fixture covers one feature.
+- **Backlog items in ZA.Inject and ZA.AsyncEvents** — separate workstreams, separate PRs.

--- a/docs/plans/2026-05-28-aot-smoke-validation-paths.md
+++ b/docs/plans/2026-05-28-aot-smoke-validation-paths.md
@@ -1,0 +1,505 @@
+# aot-smoke Validation Paths Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Extend `samples/ZeroAlloc.Validation.AotSmoke/` to cover three previously-uncovered generator-emission paths under `PublishAot=true`: `[ValidateWith(typeof(...))]`, nested `IReadOnlyList<[Validate] T>` with indexed PropertyName, and cross-property `[Must(nameof(Method))]` predicates. Closes backlog item B4.
+
+**Architecture:** Three new independent fixture files (`Letter.cs`, `Order.cs`, `DateRange.cs`), each focused on one path. Three new assertion blocks appended to `Program.cs` — each block exercises invalid + valid input and asserts failure count AND PropertyName patterns (including the load-bearing `Items[1]` indexed PropertyName for the nested case). No library changes; smoke + backlog strikethrough only.
+
+**Tech Stack:** .NET 10, `PublishAot=true`, BenchmarkDotNet not involved (this is a runtime correctness smoke, not a perf smoke).
+
+**Design doc:** `docs/plans/2026-05-28-aot-smoke-validation-paths-design.md` (committed at `25ca4ee`).
+
+**Working branch:** `chore/aot-smoke-cover-validation-paths` (off `main` at `17a6dbb`; design committed).
+
+---
+
+## Phase 0 — Orient (5 min)
+
+### Task 0.1: Read the existing smoke + Validation library APIs
+
+**Files (read-only):**
+
+- `samples/ZeroAlloc.Validation.AotSmoke/Program.cs` — current shape; new blocks follow this assertion idiom (`if (failed) { Error.WriteLine; return 1; }`).
+- `samples/ZeroAlloc.Validation.AotSmoke/Address.cs` — current `[Validate]` fixture; new fixtures follow this file structure (one type per file, `ZeroAlloc.Validation.AotSmoke` namespace).
+- `src/ZeroAlloc.Validation/Core/ValidatorFor.cs` — confirms the signature for fixture 1's `PostcodeValidator`: override `public abstract ValidationResult Validate(T instance);`.
+- `src/ZeroAlloc.Validation/Core/ValidationResult.cs` — `IsValid` + `Failures` (`ReadOnlySpan<ValidationFailure>`).
+- `src/ZeroAlloc.Validation/Core/ValidationFailure.cs` (or grep for the struct) — has `PropertyName`, `ErrorMessage`, `ErrorCode`, `Severity`.
+- `src/ZeroAlloc.Validation/Attributes/ValidateWithAttribute.cs` — confirms `[ValidateWith(typeof(...))]` on properties.
+- `src/ZeroAlloc.Validation/Attributes/MustAttribute.cs` — confirms `[Must(string methodName)]` on properties.
+- `docs/attributes.md` lines around `[Must]` — confirms the method signature: instance method `bool MethodName(TPropType value)` on the model.
+
+---
+
+## Phase 1 — Fixture 1: `[ValidateWith]` (35 min, 5 tasks)
+
+### Task 1.1: Write `Letter.cs`
+
+**File (NEW):** `samples/ZeroAlloc.Validation.AotSmoke/Letter.cs`
+
+```csharp
+using ZeroAlloc.Validation;
+
+namespace ZeroAlloc.Validation.AotSmoke;
+
+// External (non-[Validate]) type — the generator can't emit a validator
+// for it directly. [ValidateWith] points at a hand-written ValidatorFor<T>.
+public sealed class Postcode
+{
+    public string Value { get; set; } = "";
+}
+
+// User-written ValidatorFor<Postcode> — exercises the [ValidateWith] path
+// end-to-end. The generator emits a call into this validator at the
+// [ValidateWith]-annotated property's evaluation site.
+public sealed class PostcodeValidator : ValidatorFor<Postcode>
+{
+    public override ValidationResult Validate(Postcode instance)
+    {
+        if (string.IsNullOrEmpty(instance.Value))
+        {
+            return new ValidationResult(new[]
+            {
+                new ValidationFailure
+                {
+                    PropertyName = nameof(Postcode.Value),
+                    ErrorMessage = "Postcode is required.",
+                    ErrorCode = null,
+                    Severity = Severity.Error,
+                },
+            });
+        }
+        return new ValidationResult(System.Array.Empty<ValidationFailure>());
+    }
+}
+
+[Validate]
+public sealed class Letter
+{
+    [ValidateWith(typeof(PostcodeValidator))]
+    public Postcode Postcode { get; set; } = new();
+}
+```
+
+If `Severity.Error` isn't the canonical name (e.g. `Severity.Critical` or some other naming), confirm against the actual enum and adjust. Same for the `ValidationResult` constructor signature if it differs from `(ValidationFailure[])`.
+
+### Task 1.2: Append the assertion block to `Program.cs`
+
+**File (MOD):** `samples/ZeroAlloc.Validation.AotSmoke/Program.cs`
+
+After the existing `Address` block (current line 33, after `return 0;` becomes a marker — actually `return 0;` is the FINAL line; assertion blocks go BEFORE it).
+
+Read the file, find the final `Console.WriteLine("AOT smoke: PASS");` line, and append before it:
+
+```csharp
+// Fixture 1: [ValidateWith] pointing at an external ValidatorFor<T>.
+// Generator emits a call into PostcodeValidator at the [ValidateWith]
+// site. Failure flows back into the parent Letter's failures.
+var letterValidator = new LetterValidator();
+
+// Invalid: empty Postcode.Value → 1 failure routed through PostcodeValidator.
+var emptyLetter = letterValidator.Validate(new Letter { Postcode = new() });
+if (emptyLetter.IsValid)
+{
+    Console.Error.WriteLine("AOT smoke: FAIL — Letter with empty Postcode should be invalid");
+    return 1;
+}
+
+var emptyLetterFailures = System.Linq.Enumerable.ToArray(System.MemoryExtensions.ToArray(emptyLetter.Failures));
+// NOTE: ReadOnlySpan can't be passed to LINQ directly; use index/length iteration.
+// Rewrite the count + pattern check inline:
+int letterFailureCount = 0;
+bool letterHasPostcodePropertyName = false;
+foreach (ref readonly var f in emptyLetter.Failures)
+{
+    letterFailureCount++;
+    if (f.PropertyName.Contains("Postcode", System.StringComparison.Ordinal))
+        letterHasPostcodePropertyName = true;
+}
+if (letterFailureCount != 1 || !letterHasPostcodePropertyName)
+{
+    Console.Error.WriteLine($"AOT smoke: FAIL — Letter expected 1 failure with Postcode in PropertyName, got {letterFailureCount} failures (PostcodeMatch={letterHasPostcodePropertyName})");
+    return 1;
+}
+
+// Valid: populated Postcode.Value → 0 failures.
+var validLetter = letterValidator.Validate(new Letter { Postcode = new() { Value = "1234 AB" } });
+if (!validLetter.IsValid)
+{
+    Console.Error.WriteLine("AOT smoke: FAIL — Letter with populated Postcode should be valid");
+    return 1;
+}
+```
+
+The `ReadOnlySpan<ValidationFailure>` iteration uses `foreach ref readonly var` per the existing patterns in `tests/ZeroAlloc.Validation.Tests/`. If the test suite uses a different convention (e.g. `Failures.ToArray()` via a helper), match that.
+
+The exact `letterValidator` class name (`LetterValidator`) is the generator's emission convention — confirm by inspecting an existing `*Validator` reference in either the smoke or the tests.
+
+### Task 1.3: Build the smoke project
+
+```bash
+cd c:/Projects/Prive/ZeroAlloc/ZeroAlloc.Validation
+dotnet build samples/ZeroAlloc.Validation.AotSmoke/ZeroAlloc.Validation.AotSmoke.csproj -c Release 2>&1 | tail -20
+```
+
+Expected: build succeeds. If it fails:
+- **Generator can't find `PostcodeValidator`** — the `[ValidateWith(typeof(PostcodeValidator))]` reference must compile. Check namespace + visibility.
+- **`Severity.Error` not the enum value** — adjust to actual member.
+- **`ValidationResult` constructor signature mismatch** — adjust to actual.
+
+If the build succeeds but warnings about IL2026/IL3050 surface, they'll be promoted to errors per the csproj's `<WarningsAsErrors>`. Investigate and fix before continuing.
+
+### Task 1.4: Local smoke run (best-effort under Windows AOT toolchain)
+
+```bash
+dotnet publish samples/ZeroAlloc.Validation.AotSmoke/ZeroAlloc.Validation.AotSmoke.csproj -c Release -o ./aot-out 2>&1 | tail -10
+./aot-out/ZeroAlloc.Validation.AotSmoke
+```
+
+Expected: `AOT smoke: PASS` + exit 0. If native link fails on Windows (no clang, no link.exe in PATH, etc.), skip this step — CI will run it on ubuntu-latest with clang+zlib installed.
+
+If the build step passed but a `dotnet run -c Release` (no publish) fails the assertion, that's a meaningful failure — investigate before committing.
+
+### Task 1.5: Commit Fixture 1
+
+```bash
+git add samples/ZeroAlloc.Validation.AotSmoke/Letter.cs \
+        samples/ZeroAlloc.Validation.AotSmoke/Program.cs
+git commit -m "chore(aot-smoke): cover [ValidateWith] via PostcodeValidator fixture
+
+External (non-[Validate]) Postcode type with a hand-written
+ValidatorFor<Postcode>. [ValidateWith(typeof(PostcodeValidator))] on
+the Letter.Postcode property exercises the generator's external-validator
+emission path. Asserts both failure count (1) and PropertyName pattern
+(contains 'Postcode') under PublishAot=true."
+```
+
+---
+
+## Phase 2 — Fixture 2: Nested `IReadOnlyList<[Validate] T>` (35 min, 5 tasks)
+
+### Task 2.1: Write `Order.cs`
+
+**File (NEW):** `samples/ZeroAlloc.Validation.AotSmoke/Order.cs`
+
+```csharp
+using System.Collections.Generic;
+using ZeroAlloc.Validation;
+
+namespace ZeroAlloc.Validation.AotSmoke;
+
+[Validate]
+public sealed class OrderItem
+{
+    [NotEmpty(Message = "Sku is required.")]
+    public string Sku { get; set; } = "";
+}
+
+[Validate]
+public sealed class Order
+{
+    [NotEmpty] public string CustomerName { get; set; } = "";
+    public IReadOnlyList<OrderItem> Items { get; set; } = System.Array.Empty<OrderItem>();
+}
+```
+
+The generator detects `OrderItem` is `[Validate]`-decorated and emits a `foreach` in `OrderValidator.Validate` that runs `new OrderItemValidator().Validate(item)` per element, with PropertyName prefixed `Items[N].` per documented behavior. The 1.4.1 fix (B3) ensured the null-guard around the loop element is correctly omitted for value-type elements — `OrderItem` is a class here, not a struct, so the guard fires (a regression-net test for that case would be a separate smoke addition; not in scope for B4).
+
+### Task 2.2: Append the nested assertion block to Program.cs
+
+**File (MOD):** `samples/ZeroAlloc.Validation.AotSmoke/Program.cs`
+
+Append before the final `Console.WriteLine("AOT smoke: PASS");`:
+
+```csharp
+// Fixture 2: Nested IReadOnlyList<[Validate] OrderItem> with per-item indexing.
+// Generator emits a foreach over Items, validating each via OrderItemValidator
+// and emitting failures with PropertyName "Items[N].Sku" — the indexed
+// PropertyName is the load-bearing invariant.
+var orderValidator = new OrderValidator();
+
+// Invalid: one valid item at [0], one invalid item at [1].
+var mixedOrder = orderValidator.Validate(new Order
+{
+    CustomerName = "Alice",
+    Items = new[]
+    {
+        new OrderItem { Sku = "SKU-1" },
+        new OrderItem { Sku = "" }, // index 1 — invalid
+    },
+});
+if (mixedOrder.IsValid)
+{
+    Console.Error.WriteLine("AOT smoke: FAIL — Order with one invalid item should be invalid");
+    return 1;
+}
+
+int mixedFailureCount = 0;
+bool mixedHasIndexedPropertyName = false;
+foreach (ref readonly var f in mixedOrder.Failures)
+{
+    mixedFailureCount++;
+    if (f.PropertyName.Contains("Items[1]", System.StringComparison.Ordinal))
+        mixedHasIndexedPropertyName = true;
+}
+if (mixedFailureCount != 1 || !mixedHasIndexedPropertyName)
+{
+    Console.Error.WriteLine($"AOT smoke: FAIL — Order expected 1 failure with 'Items[1]' in PropertyName, got {mixedFailureCount} failures (IndexedMatch={mixedHasIndexedPropertyName})");
+    foreach (ref readonly var f in mixedOrder.Failures)
+        Console.Error.WriteLine($"  failure: PropertyName='{f.PropertyName}', ErrorMessage='{f.ErrorMessage}'");
+    return 1;
+}
+
+// Valid: all items valid + valid CustomerName.
+var validOrder = orderValidator.Validate(new Order
+{
+    CustomerName = "Alice",
+    Items = new[] { new OrderItem { Sku = "SKU-1" } },
+});
+if (!validOrder.IsValid)
+{
+    Console.Error.WriteLine("AOT smoke: FAIL — fully-valid Order should be valid");
+    return 1;
+}
+```
+
+If the generator's actual PropertyName format differs from `Items[1].Sku` (e.g. `[1].Sku` or `Items[1]`), adjust the substring assertion to whatever the generator emits. The first run will reveal it via the diagnostic output of the failure case.
+
+### Task 2.3: Build + run
+
+```bash
+dotnet build samples/ZeroAlloc.Validation.AotSmoke/ZeroAlloc.Validation.AotSmoke.csproj -c Release 2>&1 | tail -10
+```
+
+Expected: build succeeds.
+
+If the assertion fails at runtime because PropertyName format differs, the diagnostic `Console.Error.WriteLine` block above prints the actual `PropertyName`. Use that to adjust the substring.
+
+### Task 2.4: Commit Fixture 2
+
+```bash
+git add samples/ZeroAlloc.Validation.AotSmoke/Order.cs \
+        samples/ZeroAlloc.Validation.AotSmoke/Program.cs
+git commit -m "chore(aot-smoke): cover nested IReadOnlyList<[Validate]> with indexed PropertyName
+
+Order with IReadOnlyList<OrderItem> exercises the generator's per-element
+foreach + indexed PropertyName emission. Asserts the load-bearing
+'Items[1]' substring in PropertyName for a failure at the second element —
+catches a regression that loses the index reporting."
+```
+
+### Task 2.5: Confirm the existing Address smoke still passes
+
+```bash
+dotnet build samples/ZeroAlloc.Validation.AotSmoke/ZeroAlloc.Validation.AotSmoke.csproj -c Release
+# If a local AOT toolchain is available, also:
+dotnet publish samples/ZeroAlloc.Validation.AotSmoke/ZeroAlloc.Validation.AotSmoke.csproj -c Release -o ./aot-out && ./aot-out/ZeroAlloc.Validation.AotSmoke
+```
+
+Expected: `AOT smoke: PASS`. The existing Address block + new Letter block + new Order block all green.
+
+---
+
+## Phase 3 — Fixture 3: Cross-property `[Must]` (25 min, 4 tasks)
+
+### Task 3.1: Write `DateRange.cs`
+
+**File (NEW):** `samples/ZeroAlloc.Validation.AotSmoke/DateRange.cs`
+
+```csharp
+using System;
+using ZeroAlloc.Validation;
+
+namespace ZeroAlloc.Validation.AotSmoke;
+
+[Validate]
+public sealed class DateRange
+{
+    public DateTime StartDate { get; set; }
+
+    [Must(nameof(IsAfterStart), Message = "EndDate must be after StartDate.")]
+    public DateTime EndDate { get; set; }
+
+    // Instance method — generator emits a direct call (no reflection).
+    // The body sees `this.StartDate` for the cross-property comparison.
+    public bool IsAfterStart(DateTime endValue) => endValue > StartDate;
+}
+```
+
+If `MustAttribute` doesn't accept a `Message` property (the snippet above is the docs' canonical form — verify against the actual `MustAttribute` source from Phase 0), drop the `Message = "..."` part and rely on whatever default message the generator emits.
+
+### Task 3.2: Append the [Must] assertion block to Program.cs
+
+**File (MOD):** `samples/ZeroAlloc.Validation.AotSmoke/Program.cs`
+
+Append before the final `Console.WriteLine("AOT smoke: PASS");`:
+
+```csharp
+// Fixture 3: Cross-property [Must] predicate.
+// Generator emits a direct call to IsAfterStart(this.EndDate) on the model.
+// The method accesses this.StartDate for the cross-property comparison.
+var dateRangeValidator = new DateRangeValidator();
+
+var anchor = new DateTime(2026, 5, 28);
+
+// Invalid: EndDate before StartDate.
+var badRange = dateRangeValidator.Validate(new DateRange
+{
+    StartDate = anchor.AddDays(1),
+    EndDate = anchor,
+});
+if (badRange.IsValid)
+{
+    Console.Error.WriteLine("AOT smoke: FAIL — DateRange with EndDate < StartDate should be invalid");
+    return 1;
+}
+
+int badRangeFailureCount = 0;
+bool badRangeHasEndDatePropertyName = false;
+foreach (ref readonly var f in badRange.Failures)
+{
+    badRangeFailureCount++;
+    if (string.Equals(f.PropertyName, "EndDate", System.StringComparison.Ordinal))
+        badRangeHasEndDatePropertyName = true;
+}
+if (badRangeFailureCount != 1 || !badRangeHasEndDatePropertyName)
+{
+    Console.Error.WriteLine($"AOT smoke: FAIL — DateRange expected 1 failure with PropertyName='EndDate', got {badRangeFailureCount} failures (EndDateMatch={badRangeHasEndDatePropertyName})");
+    foreach (ref readonly var f in badRange.Failures)
+        Console.Error.WriteLine($"  failure: PropertyName='{f.PropertyName}', ErrorMessage='{f.ErrorMessage}'");
+    return 1;
+}
+
+// Valid: EndDate after StartDate.
+var goodRange = dateRangeValidator.Validate(new DateRange
+{
+    StartDate = anchor,
+    EndDate = anchor.AddDays(1),
+});
+if (!goodRange.IsValid)
+{
+    Console.Error.WriteLine("AOT smoke: FAIL — DateRange with EndDate > StartDate should be valid");
+    return 1;
+}
+```
+
+The `EndDate` PropertyName exact-match assertion is tighter than the `Contains` check used in fixtures 1+2 — `[Must]` on a single property should produce exactly that PropertyName. If the generator's actual emission differs (e.g. it appends the method name like `EndDate.IsAfterStart`), adjust to a `Contains` check.
+
+### Task 3.3: Build + run
+
+```bash
+dotnet build samples/ZeroAlloc.Validation.AotSmoke/ZeroAlloc.Validation.AotSmoke.csproj -c Release 2>&1 | tail -10
+```
+
+Expected: build succeeds.
+
+### Task 3.4: Commit Fixture 3
+
+```bash
+git add samples/ZeroAlloc.Validation.AotSmoke/DateRange.cs \
+        samples/ZeroAlloc.Validation.AotSmoke/Program.cs
+git commit -m "chore(aot-smoke): cover cross-property [Must] predicate
+
+DateRange.[Must(nameof(IsAfterStart))] on EndDate exercises the
+generator's cross-property predicate emission. The IsAfterStart
+instance method sees this.StartDate via implicit capture. Asserts
+PropertyName exact-match 'EndDate' on the failure — catches a
+regression in [Must]'s emission shape."
+```
+
+---
+
+## Phase 4 — Strike B4 + push + PR (15 min, 3 tasks)
+
+### Task 4.1: Update `docs/backlog.md`
+
+Read the file to find the existing B4 entry (added by PR #49). Replace its content with the struck-through shipped marker:
+
+```markdown
+## ~~B4 — Extend aot-smoke to cover `[ValidateWith]`, nested chains, cross-property `[Must]` predicates~~ — ✅ shipped 2026-05-28
+
+**Shipped:** Three new fixtures in `samples/ZeroAlloc.Validation.AotSmoke/` (`Letter.cs`, `Order.cs`, `DateRange.cs`) plus matching assertion blocks in `Program.cs` exercise the three previously-uncovered generator-emission paths. Asserts both invalid + valid input, both failure count + PropertyName patterns — including the load-bearing `Items[1]` indexed PropertyName for the nested-collection case.
+
+**Design + plan:** [`docs/plans/2026-05-28-aot-smoke-validation-paths-design.md`](plans/2026-05-28-aot-smoke-validation-paths-design.md) + [`docs/plans/2026-05-28-aot-smoke-validation-paths.md`](plans/2026-05-28-aot-smoke-validation-paths.md).
+```
+
+Replace the existing B4 block (the open "What/Why/Sketch/Tradeoff/Graduation signal" form) with the above. Don't add a new entry — strikethrough in place.
+
+### Task 4.2: Full smoke check + commit docs
+
+```bash
+cd c:/Projects/Prive/ZeroAlloc/ZeroAlloc.Validation
+dotnet build -c Release 2>&1 | tail -10
+```
+
+Expected: full solution builds. The smoke project compiles; existing test suite still passes (no library changes, but build = all projects).
+
+```bash
+git add docs/backlog.md
+git commit -m "docs(backlog): strike B4 shipped (aot-smoke coverage extension)"
+```
+
+### Task 4.3: Push + open PR + STOP
+
+```bash
+git push -u origin chore/aot-smoke-cover-validation-paths
+
+gh pr create \
+  --title "chore(aot-smoke): cover ValidateWith, nested, cross-property Must paths" \
+  --body "$(cat <<'EOF'
+## Summary
+
+Closes backlog item B4. The existing aot-smoke project covered only the simple `[Validate]` + `[NotEmpty]` baseline; this PR adds three independent fixtures + assertion blocks exercising the three previously-uncovered generator-emission paths:
+
+- `[ValidateWith(typeof(PostcodeValidator))]` — external user-written `ValidatorFor<T>` invocation
+- Nested `IReadOnlyList<[Validate] OrderItem>` — per-element foreach with indexed `Items[N].Sku` PropertyName
+- Cross-property `[Must(nameof(IsAfterStart))]` — instance-method predicate accessing other properties via `this.`
+
+## Why now
+
+Surfaced 2026-05-28 during the org-wide aot-smoke coverage survey done after [ZeroAlloc.Serialisation](https://github.com/ZeroAlloc-Net/ZeroAlloc.Serialisation) shipped 2.3.1 + 2.3.2 reactively. ZA.Serialisation's smoke covered only the V0 path; V1 paths were left un-validated and downstream templates discovered the gap. Same "smoke exists but partial" pattern applied to ZA.Validation; this PR closes it.
+
+## What changed
+
+- 3 new fixture files (`Letter.cs`, `Order.cs`, `DateRange.cs`)
+- 3 new assertion blocks in `Program.cs` (~70 LOC)
+- 1 line in `docs/backlog.md` — B4 entry struck shipped
+
+## Decisions ([design doc](docs/plans/2026-05-28-aot-smoke-validation-paths-design.md))
+
+- **Three independent fixtures, not one combined** — failure messages pinpoint which feature regressed
+- **Tight assertions (count AND PropertyName)** — catches index-dropped regressions in nested case, predicate-mistargeted regressions in [Must] case
+- **No in-process tests added** — existing `tests/ZeroAlloc.Validation.Tests/` suite already covers JIT; smoke is the AOT-specific net
+
+## SemVer
+
+No package version bump — CI-only changes. release-please will treat as `chore:` and skip the release manifest.
+
+## Test plan
+
+- [x] Local build clean
+- [ ] CI build clean
+- [ ] CI aot-smoke job passes
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+**STOP** after PR opens. Do NOT admin-merge.
+
+---
+
+## Verification checklist
+
+- [ ] **Phase 1:** Letter fixture compiles + assertion fires correctly for empty Postcode.Value
+- [ ] **Phase 2:** Order fixture compiles + `Items[1]` substring appears in PropertyName for the indexed failure
+- [ ] **Phase 3:** DateRange fixture compiles + `EndDate` exact-match PropertyName on the [Must] failure
+- [ ] **Phase 4:** B4 backlog struck through, PR opens cleanly with all three fixtures present
+
+## Out of scope (deferred to backlog or future PRs)
+
+- **Empty-list semantics test** for Order — the "valid Order" assertion happens to validate empty/non-empty list handling as a side-effect
+- **Multi-feature combinations** — a fixture exercising e.g. ValidateWith + Must + nesting simultaneously. YAGNI
+- **Backlog items in ZA.Inject (#66) and ZA.AsyncEvents (#75)** — separate workstreams, separate PRs
+- **B3 regression-net for value-type nested elements** — ZA.Validation 1.4.1 fixed this case; a smoke fixture for `IReadOnlyList<[Validate] readonly record struct>` would be belt-and-suspenders; defer

--- a/samples/ZeroAlloc.Validation.AotSmoke/DateRange.cs
+++ b/samples/ZeroAlloc.Validation.AotSmoke/DateRange.cs
@@ -1,0 +1,18 @@
+using System;
+using ZeroAlloc.Validation;
+
+namespace ZeroAlloc.Validation.AotSmoke;
+
+[Validate]
+public sealed class DateRange
+{
+    public DateTime StartDate { get; set; }
+
+    [Must(nameof(IsAfterStart))]
+    public DateTime EndDate { get; set; }
+
+    // Instance method — generator emits a direct call. Sees this.StartDate
+    // for the cross-property comparison.
+    // Signature per docs/attributes.md: bool MethodName(TPropType value).
+    public bool IsAfterStart(DateTime endValue) => endValue > StartDate;
+}

--- a/samples/ZeroAlloc.Validation.AotSmoke/Letter.cs
+++ b/samples/ZeroAlloc.Validation.AotSmoke/Letter.cs
@@ -1,0 +1,10 @@
+using ZeroAlloc.Validation;
+
+namespace ZeroAlloc.Validation.AotSmoke;
+
+[Validate]
+public sealed class Letter
+{
+    [ValidateWith(typeof(PostcodeValidator))]
+    public Postcode Postcode { get; set; } = new();
+}

--- a/samples/ZeroAlloc.Validation.AotSmoke/Order.cs
+++ b/samples/ZeroAlloc.Validation.AotSmoke/Order.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+using ZeroAlloc.Validation;
+
+namespace ZeroAlloc.Validation.AotSmoke;
+
+[Validate]
+public sealed class Order
+{
+    [NotEmpty] public string CustomerName { get; set; } = "";
+    public IReadOnlyList<OrderItem> Items { get; set; } = System.Array.Empty<OrderItem>();
+}

--- a/samples/ZeroAlloc.Validation.AotSmoke/OrderItem.cs
+++ b/samples/ZeroAlloc.Validation.AotSmoke/OrderItem.cs
@@ -1,0 +1,10 @@
+using ZeroAlloc.Validation;
+
+namespace ZeroAlloc.Validation.AotSmoke;
+
+[Validate]
+public sealed class OrderItem
+{
+    [NotEmpty(Message = "Sku is required.")]
+    public string Sku { get; set; } = "";
+}

--- a/samples/ZeroAlloc.Validation.AotSmoke/Postcode.cs
+++ b/samples/ZeroAlloc.Validation.AotSmoke/Postcode.cs
@@ -1,0 +1,8 @@
+namespace ZeroAlloc.Validation.AotSmoke;
+
+// External (non-[Validate]) type — the generator can't emit a validator
+// for it directly. [ValidateWith] points at a hand-written ValidatorFor<T>.
+public sealed class Postcode
+{
+    public string Value { get; set; } = "";
+}

--- a/samples/ZeroAlloc.Validation.AotSmoke/PostcodeValidator.cs
+++ b/samples/ZeroAlloc.Validation.AotSmoke/PostcodeValidator.cs
@@ -1,0 +1,27 @@
+using ZeroAlloc.Validation;
+
+namespace ZeroAlloc.Validation.AotSmoke;
+
+// User-written ValidatorFor<Postcode> — exercises the [ValidateWith] path
+// end-to-end. The generator emits a call into this validator at the
+// [ValidateWith]-annotated property's evaluation site.
+public sealed class PostcodeValidator : ValidatorFor<Postcode>
+{
+    public override ValidationResult Validate(Postcode instance)
+    {
+        if (string.IsNullOrEmpty(instance.Value))
+        {
+            return new ValidationResult(new[]
+            {
+                new ValidationFailure
+                {
+                    PropertyName = nameof(Postcode.Value),
+                    ErrorMessage = "Postcode is required.",
+                    ErrorCode = null,
+                    Severity = Severity.Error,
+                },
+            });
+        }
+        return new ValidationResult(System.Array.Empty<ValidationFailure>());
+    }
+}

--- a/samples/ZeroAlloc.Validation.AotSmoke/Program.cs
+++ b/samples/ZeroAlloc.Validation.AotSmoke/Program.cs
@@ -126,5 +126,56 @@ if (!validOrder.IsValid)
     return 1;
 }
 
+// Fixture 3: Cross-property [Must] predicate.
+// Generator emits a direct call to the instance method IsAfterStart(endValue),
+// which sees this.StartDate via implicit capture — that's the cross-property
+// semantic. PropertyName should be exactly "EndDate" (no method-name suffix).
+var dateRangeValidator = new DateRangeValidator();
+var anchor = new DateTime(2026, 1, 1);
+
+// Invalid: EndDate before StartDate → 1 failure on EndDate.
+var badRange = dateRangeValidator.Validate(new DateRange
+{
+    StartDate = anchor.AddDays(1),
+    EndDate = anchor,
+});
+if (badRange.IsValid)
+{
+    Console.Error.WriteLine("AOT smoke: FAIL — DateRange with EndDate before StartDate should be invalid");
+    return 1;
+}
+
+int dateRangeFailureCount = 0;
+bool dateRangeHasEndDatePropertyName = false;
+foreach (ref readonly var f in badRange.Failures)
+{
+    dateRangeFailureCount++;
+#pragma warning disable EPS06 // False positive: ValidationFailure is a readonly struct
+    if (string.Equals(f.PropertyName, "EndDate", StringComparison.Ordinal))
+#pragma warning restore EPS06
+        dateRangeHasEndDatePropertyName = true;
+}
+if (dateRangeFailureCount != 1 || !dateRangeHasEndDatePropertyName)
+{
+    Console.Error.WriteLine($"AOT smoke: FAIL — DateRange expected 1 failure with PropertyName=='EndDate', got {dateRangeFailureCount} failures (EndDateMatch={dateRangeHasEndDatePropertyName})");
+    foreach (ref readonly var f in badRange.Failures)
+#pragma warning disable EPS06 // False positive: ValidationFailure is a readonly struct
+        Console.Error.WriteLine($"  failure: PropertyName='{f.PropertyName}', ErrorMessage='{f.ErrorMessage}'");
+#pragma warning restore EPS06
+    return 1;
+}
+
+// Valid: EndDate after StartDate → 0 failures.
+var goodRange = dateRangeValidator.Validate(new DateRange
+{
+    StartDate = anchor,
+    EndDate = anchor.AddDays(1),
+});
+if (!goodRange.IsValid)
+{
+    Console.Error.WriteLine("AOT smoke: FAIL — DateRange with EndDate after StartDate should be valid");
+    return 1;
+}
+
 Console.WriteLine("AOT smoke: PASS");
 return 0;

--- a/samples/ZeroAlloc.Validation.AotSmoke/Program.cs
+++ b/samples/ZeroAlloc.Validation.AotSmoke/Program.cs
@@ -72,5 +72,59 @@ if (!validLetter.IsValid)
     return 1;
 }
 
+// Fixture 2: Nested IReadOnlyList<[Validate] OrderItem> with per-item indexing.
+// Generator emits a foreach over Items, validating each via OrderItemValidator
+// and emitting failures with PropertyName "Items[N].Sku" — the indexed
+// PropertyName is the load-bearing invariant.
+var orderValidator = new OrderValidator(new OrderItemValidator());
+
+// Invalid: one valid item at [0], one invalid item at [1].
+var mixedOrder = orderValidator.Validate(new Order
+{
+    CustomerName = "Alice",
+    Items = new[]
+    {
+        new OrderItem { Sku = "SKU-1" },
+        new OrderItem { Sku = "" }, // index 1 — invalid
+    },
+});
+if (mixedOrder.IsValid)
+{
+    Console.Error.WriteLine("AOT smoke: FAIL — Order with one invalid item should be invalid");
+    return 1;
+}
+
+int mixedFailureCount = 0;
+bool mixedHasIndexedPropertyName = false;
+foreach (ref readonly var f in mixedOrder.Failures)
+{
+    mixedFailureCount++;
+#pragma warning disable EPS06 // False positive: ValidationFailure is a readonly struct
+    if (f.PropertyName.Contains("Items[1]", System.StringComparison.Ordinal))
+#pragma warning restore EPS06
+        mixedHasIndexedPropertyName = true;
+}
+if (mixedFailureCount != 1 || !mixedHasIndexedPropertyName)
+{
+    Console.Error.WriteLine($"AOT smoke: FAIL — Order expected 1 failure with 'Items[1]' in PropertyName, got {mixedFailureCount} failures (IndexedMatch={mixedHasIndexedPropertyName})");
+    foreach (ref readonly var f in mixedOrder.Failures)
+#pragma warning disable EPS06 // False positive: ValidationFailure is a readonly struct
+        Console.Error.WriteLine($"  failure: PropertyName='{f.PropertyName}', ErrorMessage='{f.ErrorMessage}'");
+#pragma warning restore EPS06
+    return 1;
+}
+
+// Valid: all items valid + valid CustomerName.
+var validOrder = orderValidator.Validate(new Order
+{
+    CustomerName = "Alice",
+    Items = new[] { new OrderItem { Sku = "SKU-1" } },
+});
+if (!validOrder.IsValid)
+{
+    Console.Error.WriteLine("AOT smoke: FAIL — fully-valid Order should be valid");
+    return 1;
+}
+
 Console.WriteLine("AOT smoke: PASS");
 return 0;

--- a/samples/ZeroAlloc.Validation.AotSmoke/Program.cs
+++ b/samples/ZeroAlloc.Validation.AotSmoke/Program.cs
@@ -30,5 +30,47 @@ if (!ok.IsValid)
     return 1;
 }
 
+// Fixture 1: [ValidateWith] pointing at an external ValidatorFor<T>.
+// Generator emits a ctor that takes the external ValidatorFor<T> via DI,
+// then calls into it at the [ValidateWith] site. Failure flows back into
+// the parent Letter's failures.
+var letterValidator = new LetterValidator(new PostcodeValidator());
+
+// Invalid: empty Postcode.Value → 1 failure routed through PostcodeValidator.
+var emptyLetter = letterValidator.Validate(new Letter { Postcode = new() });
+if (emptyLetter.IsValid)
+{
+    Console.Error.WriteLine("AOT smoke: FAIL — Letter with empty Postcode should be invalid");
+    return 1;
+}
+
+int letterFailureCount = 0;
+bool letterHasPostcodePropertyName = false;
+foreach (ref readonly var f in emptyLetter.Failures)
+{
+    letterFailureCount++;
+#pragma warning disable EPS06 // False positive: ValidationFailure is a readonly struct
+    if (f.PropertyName.Contains("Postcode", System.StringComparison.Ordinal))
+#pragma warning restore EPS06
+        letterHasPostcodePropertyName = true;
+}
+if (letterFailureCount != 1 || !letterHasPostcodePropertyName)
+{
+    Console.Error.WriteLine($"AOT smoke: FAIL — Letter expected 1 failure with Postcode in PropertyName, got {letterFailureCount} failures (PostcodeMatch={letterHasPostcodePropertyName})");
+    foreach (ref readonly var f in emptyLetter.Failures)
+#pragma warning disable EPS06 // False positive: ValidationFailure is a readonly struct
+        Console.Error.WriteLine($"  failure: PropertyName='{f.PropertyName}', ErrorMessage='{f.ErrorMessage}'");
+#pragma warning restore EPS06
+    return 1;
+}
+
+// Valid: populated Postcode.Value → 0 failures.
+var validLetter = letterValidator.Validate(new Letter { Postcode = new() { Value = "1234 AB" } });
+if (!validLetter.IsValid)
+{
+    Console.Error.WriteLine("AOT smoke: FAIL — Letter with populated Postcode should be valid");
+    return 1;
+}
+
 Console.WriteLine("AOT smoke: PASS");
 return 0;


### PR DESCRIPTION
## Summary

Closes backlog item B4. The existing aot-smoke project covered only the simple `[Validate]` + `[NotEmpty]` baseline; this PR adds three independent fixtures + assertion blocks exercising the three previously-uncovered generator-emission paths under `PublishAot=true`:

- `[ValidateWith(typeof(PostcodeValidator))]` — external user-written `ValidatorFor<T>` invocation
- Nested `IReadOnlyList<[Validate] OrderItem>` — per-element foreach with indexed `Items[1].Sku` PropertyName
- Cross-property `[Must(nameof(IsAfterStart))]` — instance-method predicate accessing other properties via `this.`

## Why now

Surfaced 2026-05-28 during the org-wide aot-smoke coverage survey done after [ZeroAlloc.Serialisation](https://github.com/ZeroAlloc-Net/ZeroAlloc.Serialisation) shipped 2.3.1 + 2.3.2 reactively. ZA.Serialisation's smoke covered only the V0 path; V1 paths were left un-validated and downstream templates discovered the gap. Same "smoke exists but partial" pattern applied to ZA.Validation; this PR closes it.

## What changed

- 6 new fixture files (3 features split per the `MA0048` one-type-per-file rule):
  - `Letter.cs` + `Postcode.cs` + `PostcodeValidator.cs` (ValidateWith)
  - `Order.cs` + `OrderItem.cs` (nested)
  - `DateRange.cs` (Must)
- 3 new assertion blocks in `Program.cs` (~70 LOC) — each block: invalid case asserts failure count AND PropertyName pattern; valid case asserts IsValid; diagnostic dump on failure
- `docs/backlog.md` — B4 entry struck shipped with findings preserved

## Findings worth flagging

- **Generator emits DI-ctor injection for nested `[Validate]` types AND `[ValidateWith]` references.** Discovered when `new OrderValidator()` failed `CS7036` — fixed by `new OrderValidator(new OrderItemValidator())`. `[Must]` does NOT trigger ctor injection (it's a predicate, not a sub-validator).
- **`EPS06` false-positives on `ref readonly` to `readonly struct ValidationFailure`** — wrapped each foreach in `#pragma warning disable EPS06` to match the workaround in the library's own `ValidationAssert.cs`.
- **PropertyName format `Items[1].Sku`** for nested-collection failures — confirmed by `RuleEmitter.cs` line 371 (`"{propName}[" + idx + "]." + child.PropertyName`). The assertion's `Contains("Items[1]")` substring is tight enough to catch a regression that drops either the parent prefix or the index.

## Decisions ([design doc](docs/plans/2026-05-28-aot-smoke-validation-paths-design.md))

- **Three independent fixtures, not one combined** — failure messages pinpoint which feature regressed
- **Tight assertions (count AND PropertyName)** — catches index-dropped regressions in nested case, predicate-mistargeted regressions in [Must] case
- **No in-process tests added** — existing `tests/ZeroAlloc.Validation.Tests/` suite already covers JIT; smoke is the AOT-specific net

## SemVer

No package version bump — CI-only changes. release-please will treat as `chore:` and skip the release manifest.

## Test plan

- [x] Local build clean (`dotnet build -c Release`, 0 warnings 0 errors)
- [x] Local JIT run prints `AOT smoke: PASS`
- [ ] CI build clean
- [ ] CI aot-smoke job passes (the real AOT publish on ubuntu-latest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)