### PR TITLE
chore(aot-smoke): B3 regression coverage + backlog status alignment

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -4,7 +4,14 @@ Candidate enhancements identified during real-world usage. Each item is independ
 
 ---
 
-## B3 — Nested-validator emits `is not null` against value-type elements
+## ~~B3 — Nested-validator emits `is not null` against value-type elements~~ — ✅ shipped 1.4.1 ([PR #45](https://github.com/ZeroAlloc-Net/ZeroAlloc.Validation/pull/45))
+
+**Shipped:** `NeedsNullGuard(ITypeSymbol)` predicate in `src/ZeroAlloc.Validation.Generator/RuleEmitter.cs` returns `false` for non-nullable value types (and `true` for class types + `Nullable<T>`). Applied at both nested emission sites — `EmitNestedValidatorForProp` (scalar nested) and `EmitCollectionValidatorForProp` (list-element nested). [PR #45](https://github.com/ZeroAlloc-Net/ZeroAlloc.Validation/pull/45), merged 2026-05-27.
+
+**Regression coverage:** `samples/ZeroAlloc.Validation.AotSmoke/` gained a `readonly record struct OrderTag` fixture included as `IReadOnlyList<OrderTag>` on `Order`. The aot-smoke CI check fails with `CS0037` if the `NeedsNullGuard` predicate ever regresses.
+
+<details>
+<summary>Original B3 proposal (kept for context)</summary>
 
 **What.** When a `[Validate]` type contains `IReadOnlyList<T>` (where T is `[Validate]`-decorated) or a scalar property whose type is `[Validate]`-decorated, the generator emits `if (... is not null)` unconditionally. Class T and `Nullable<T>` compile correctly; **non-nullable value types fail with `CS0037`** (cannot convert null to a non-nullable value type).
 
@@ -18,6 +25,8 @@ Candidate enhancements identified during real-world usage. Each item is independ
 - Public API surface unchanged; pure subtractive fix at the generator-output level.
 
 **Graduation signal.** Same template surfaced the bug; landing it is the graduation. Ships as **1.4.1** (patch).
+
+</details>
 
 ---
 

--- a/samples/ZeroAlloc.Validation.AotSmoke/Order.cs
+++ b/samples/ZeroAlloc.Validation.AotSmoke/Order.cs
@@ -8,4 +8,5 @@ public sealed class Order
 {
     [NotEmpty] public string CustomerName { get; set; } = "";
     public IReadOnlyList<OrderItem> Items { get; set; } = System.Array.Empty<OrderItem>();
+    public IReadOnlyList<OrderTag> Tags { get; set; } = System.Array.Empty<OrderTag>();
 }

--- a/samples/ZeroAlloc.Validation.AotSmoke/OrderTag.cs
+++ b/samples/ZeroAlloc.Validation.AotSmoke/OrderTag.cs
@@ -1,0 +1,12 @@
+using ZeroAlloc.Validation;
+
+namespace ZeroAlloc.Validation.AotSmoke;
+
+// B3 regression coverage: a [Validate]-decorated readonly record struct included
+// as IReadOnlyList<OrderTag> on the parent Order ensures the generator's
+// NeedsNullGuard(ITypeSymbol) predicate correctly omits the `is not null` guard
+// around value-type elements. Without that predicate, the smoke build fails
+// with CS0037 (cannot convert null to a non-nullable value type).
+[Validate]
+public readonly record struct OrderTag(
+    [property: NotEmpty(Message = "Tag is required.")] string Label);

--- a/samples/ZeroAlloc.Validation.AotSmoke/Program.cs
+++ b/samples/ZeroAlloc.Validation.AotSmoke/Program.cs
@@ -76,37 +76,48 @@ if (!validLetter.IsValid)
 // Generator emits a foreach over Items, validating each via OrderItemValidator
 // and emitting failures with PropertyName "Items[N].Sku" — the indexed
 // PropertyName is the load-bearing invariant.
-var orderValidator = new OrderValidator(new OrderItemValidator());
+var orderValidator = new OrderValidator(new OrderItemValidator(), new OrderTagValidator());
 
-// Invalid: one valid item at [0], one invalid item at [1].
+// Invalid: one valid item at Items[0], one invalid item at Items[1],
+// plus one invalid tag at Tags[0]. The Tags[0] case is B3 regression
+// coverage — IReadOnlyList<OrderTag> where OrderTag is a [Validate]
+// readonly record struct. If the generator's NeedsNullGuard predicate
+// regresses, this build fails with CS0037 before this assertion ever runs.
 var mixedOrder = orderValidator.Validate(new Order
 {
     CustomerName = "Alice",
     Items = new[]
     {
         new OrderItem { Sku = "SKU-1" },
-        new OrderItem { Sku = "" }, // index 1 — invalid
+        new OrderItem { Sku = "" }, // Items[1] — invalid
+    },
+    Tags = new[]
+    {
+        new OrderTag(Label: ""), // Tags[0] — invalid
     },
 });
 if (mixedOrder.IsValid)
 {
-    Console.Error.WriteLine("AOT smoke: FAIL — Order with one invalid item should be invalid");
+    Console.Error.WriteLine("AOT smoke: FAIL — Order with one invalid item + one invalid tag should be invalid");
     return 1;
 }
 
 int mixedFailureCount = 0;
-bool mixedHasIndexedPropertyName = false;
+bool mixedHasIndexedItemPropertyName = false;
+bool mixedHasIndexedTagPropertyName = false;
 foreach (ref readonly var f in mixedOrder.Failures)
 {
     mixedFailureCount++;
 #pragma warning disable EPS06 // False positive: ValidationFailure is a readonly struct
     if (f.PropertyName.Contains("Items[1]", System.StringComparison.Ordinal))
+        mixedHasIndexedItemPropertyName = true;
+    if (f.PropertyName.Contains("Tags[0]", System.StringComparison.Ordinal))
+        mixedHasIndexedTagPropertyName = true;
 #pragma warning restore EPS06
-        mixedHasIndexedPropertyName = true;
 }
-if (mixedFailureCount != 1 || !mixedHasIndexedPropertyName)
+if (mixedFailureCount != 2 || !mixedHasIndexedItemPropertyName || !mixedHasIndexedTagPropertyName)
 {
-    Console.Error.WriteLine($"AOT smoke: FAIL — Order expected 1 failure with 'Items[1]' in PropertyName, got {mixedFailureCount} failures (IndexedMatch={mixedHasIndexedPropertyName})");
+    Console.Error.WriteLine($"AOT smoke: FAIL — Order expected 2 failures with 'Items[1]' + 'Tags[0]' in PropertyName, got {mixedFailureCount} failures (ItemsMatch={mixedHasIndexedItemPropertyName}, TagsMatch={mixedHasIndexedTagPropertyName})");
     foreach (ref readonly var f in mixedOrder.Failures)
 #pragma warning disable EPS06 // False positive: ValidationFailure is a readonly struct
         Console.Error.WriteLine($"  failure: PropertyName='{f.PropertyName}', ErrorMessage='{f.ErrorMessage}'");
@@ -114,11 +125,12 @@ if (mixedFailureCount != 1 || !mixedHasIndexedPropertyName)
     return 1;
 }
 
-// Valid: all items valid + valid CustomerName.
+// Valid: all items + all tags valid + valid CustomerName.
 var validOrder = orderValidator.Validate(new Order
 {
     CustomerName = "Alice",
     Items = new[] { new OrderItem { Sku = "SKU-1" } },
+    Tags = new[] { new OrderTag(Label: "priority") },
 });
 if (!validOrder.IsValid)
 {


### PR DESCRIPTION
## Summary

Closes the B3 backlog item. The fix itself shipped in v1.4.1 via [PR #45](https://github.com/ZeroAlloc-Net/ZeroAlloc.Validation/pull/45) (the `NeedsNullGuard` predicate in `RuleEmitter.cs`), but the aot-smoke fixture only covered the `sealed class` case (added by B4). This PR adds the `readonly record struct` regression coverage B3 was actually about + marks the backlog entry shipped.

## Changes

- `samples/ZeroAlloc.Validation.AotSmoke/OrderTag.cs` (new) — `readonly record struct` `[Validate]` fixture with a `NotEmpty` rule
- `samples/ZeroAlloc.Validation.AotSmoke/Order.cs` (modified) — adds `IReadOnlyList<OrderTag> Tags` property alongside existing `Items`
- `samples/ZeroAlloc.Validation.AotSmoke/Program.cs` (modified) — extends the Order assertion block to cover invalid + valid `Tags`
- `docs/backlog.md` (modified) — B3 section moves to shipped status; original proposal preserved in a `<details>` block

## Regression net

If `NeedsNullGuard` in `RuleEmitter.cs` ever regresses to a definition that allows the `is not null` guard around non-nullable value types, the aot-smoke build will fail with `CS0037` on this fixture before merge.

`chore:` prefix — no version bump per the established empirical mapping.

Generated with [Claude Code](https://claude.com/claude-code)